### PR TITLE
feat: database schema — all 9 MVP tables with Drizzle ORM (ClawControlDev-Leader)

### DIFF
--- a/src/db/schema/__tests__/schema.test.ts
+++ b/src/db/schema/__tests__/schema.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { getTableName, getTableColumns } from 'drizzle-orm';
+import { worlds } from '../worlds.js';
+import { hexes } from '../hexes.js';
+import { colonies } from '../colonies.js';
+import { settlements } from '../settlements.js';
+import { units } from '../units.js';
+import { actions } from '../actions.js';
+import { agreements } from '../agreements.js';
+import { messages } from '../messages.js';
+import { events } from '../events.js';
+
+describe('Database schema', () => {
+  describe('worlds table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(worlds)).toBe('worlds');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(worlds);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('name');
+      expect(cols).toHaveProperty('tickRate');
+      expect(cols).toHaveProperty('currentTick');
+      expect(cols).toHaveProperty('mapSeed');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('mapRadius');
+      expect(cols).toHaveProperty('maxColonies');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('hexes table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(hexes)).toBe('hexes');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(hexes);
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('x');
+      expect(cols).toHaveProperty('y');
+      expect(cols).toHaveProperty('terrain');
+      expect(cols).toHaveProperty('resources');
+      expect(cols).toHaveProperty('settlementId');
+      expect(cols).toHaveProperty('exploredBy');
+    });
+  });
+
+  describe('colonies table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(colonies)).toBe('colonies');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(colonies);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('name');
+      expect(cols).toHaveProperty('apiKeyHash');
+      expect(cols).toHaveProperty('resources');
+      expect(cols).toHaveProperty('legacyScore');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('settlements table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(settlements)).toBe('settlements');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(settlements);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('colonyId');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('name');
+      expect(cols).toHaveProperty('hexX');
+      expect(cols).toHaveProperty('hexY');
+      expect(cols).toHaveProperty('tier');
+      expect(cols).toHaveProperty('buildings');
+      expect(cols).toHaveProperty('buildQueue');
+      expect(cols).toHaveProperty('loyalty');
+      expect(cols).toHaveProperty('population');
+    });
+  });
+
+  describe('units table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(units)).toBe('units');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(units);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('colonyId');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('type');
+      expect(cols).toHaveProperty('hexX');
+      expect(cols).toHaveProperty('hexY');
+      expect(cols).toHaveProperty('health');
+      expect(cols).toHaveProperty('morale');
+      expect(cols).toHaveProperty('movementQueue');
+    });
+  });
+
+  describe('actions table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(actions)).toBe('actions');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(actions);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('colonyId');
+      expect(cols).toHaveProperty('tick');
+      expect(cols).toHaveProperty('type');
+      expect(cols).toHaveProperty('params');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('result');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('agreements table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(agreements)).toBe('agreements');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(agreements);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('type');
+      expect(cols).toHaveProperty('proposedBy');
+      expect(cols).toHaveProperty('proposedTo');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('terms');
+      expect(cols).toHaveProperty('proposedAtTick');
+      expect(cols).toHaveProperty('acceptedAtTick');
+    });
+  });
+
+  describe('messages table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(messages)).toBe('messages');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(messages);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('fromColony');
+      expect(cols).toHaveProperty('toColony');
+      expect(cols).toHaveProperty('sentAtTick');
+      expect(cols).toHaveProperty('deliveredAtTick');
+      expect(cols).toHaveProperty('content');
+      expect(cols).toHaveProperty('read');
+    });
+  });
+
+  describe('events table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(events)).toBe('events');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(events);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('worldId');
+      expect(cols).toHaveProperty('tick');
+      expect(cols).toHaveProperty('type');
+      expect(cols).toHaveProperty('public');
+      expect(cols).toHaveProperty('visibility');
+      expect(cols).toHaveProperty('data');
+      expect(cols).toHaveProperty('publicData');
+    });
+  });
+
+  it('all 9 tables are defined', () => {
+    const tables = [worlds, hexes, colonies, settlements, units, actions, agreements, messages, events];
+    expect(tables).toHaveLength(9);
+    tables.forEach(t => expect(getTableName(t)).toBeTruthy());
+  });
+});

--- a/src/db/schema/actions.ts
+++ b/src/db/schema/actions.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, integer, jsonb, timestamp, index } from 'drizzle-orm/pg-core';
+import { worlds } from './worlds.js';
+import { colonies } from './colonies.js';
+
+export const actions = pgTable('actions', {
+  id: text('id').primaryKey(),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  colonyId: text('colony_id').notNull().references(() => colonies.id),
+  tick: integer('tick').notNull(),
+  type: text('type').notNull(),
+  params: jsonb('params').notNull(),
+  status: text('status').notNull().default('queued'), // queued | resolved | failed
+  result: text('result'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_actions_world_tick').on(table.worldId, table.tick, table.status),
+]);

--- a/src/db/schema/agreements.ts
+++ b/src/db/schema/agreements.ts
@@ -1,0 +1,15 @@
+import { pgTable, text, integer, jsonb } from 'drizzle-orm/pg-core';
+import { worlds } from './worlds.js';
+import { colonies } from './colonies.js';
+
+export const agreements = pgTable('agreements', {
+  id: text('id').primaryKey(),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  type: text('type').notNull(), // non_aggression | trade | alliance
+  proposedBy: text('proposed_by').notNull().references(() => colonies.id),
+  proposedTo: text('proposed_to').notNull().references(() => colonies.id),
+  status: text('status').notNull().default('proposed'), // proposed | active | rejected | broken
+  terms: jsonb('terms').notNull().default({}),
+  proposedAtTick: integer('proposed_at_tick').notNull(),
+  acceptedAtTick: integer('accepted_at_tick'),
+});

--- a/src/db/schema/colonies.ts
+++ b/src/db/schema/colonies.ts
@@ -1,0 +1,19 @@
+import { pgTable, text, integer, jsonb, timestamp } from 'drizzle-orm/pg-core';
+import { worlds } from './worlds.js';
+
+export const colonies = pgTable('colonies', {
+  id: text('id').primaryKey(),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  name: text('name').notNull(),
+  apiKeyHash: text('api_key_hash').notNull(),
+  resources: jsonb('resources').notNull().default({
+    food: 100,
+    timber: 50,
+    stone: 30,
+    iron: 10,
+    influence: 50,
+  }),
+  legacyScore: integer('legacy_score').notNull().default(0),
+  status: text('status').notNull().default('active'), // active | at_war | eliminated
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});

--- a/src/db/schema/events.ts
+++ b/src/db/schema/events.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, integer, boolean, jsonb, index } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { worlds } from './worlds.js';
+
+export const events = pgTable('events', {
+  id: text('id').primaryKey(),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  tick: integer('tick').notNull(),
+  type: text('type').notNull(),
+  public: boolean('public').notNull().default(false),
+  visibility: text('visibility').array().default(sql`'{}'`),
+  data: jsonb('data').notNull(),
+  publicData: jsonb('public_data'),
+}, (table) => [
+  index('idx_events_world_tick').on(table.worldId, table.tick),
+  index('idx_events_public').on(table.worldId, table.public, table.tick),
+]);

--- a/src/db/schema/hexes.ts
+++ b/src/db/schema/hexes.ts
@@ -1,0 +1,15 @@
+import { pgTable, text, integer, jsonb, primaryKey } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { worlds } from './worlds.js';
+
+export const hexes = pgTable('hexes', {
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  x: integer('x').notNull(),
+  y: integer('y').notNull(),
+  terrain: text('terrain').notNull(), // plains | forest | mountains | coast | desert | tundra | ocean
+  resources: jsonb('resources').notNull().default({}),
+  settlementId: text('settlement_id'),
+  exploredBy: text('explored_by').array().default(sql`'{}'`),
+}, (table) => [
+  primaryKey({ columns: [table.worldId, table.x, table.y] }),
+]);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,3 +1,9 @@
-// Database schema — placeholder until #2 (database schema issue)
-// Each table will be defined in its own file and re-exported here.
-export {};
+export { worlds } from './worlds.js';
+export { hexes } from './hexes.js';
+export { colonies } from './colonies.js';
+export { settlements } from './settlements.js';
+export { units } from './units.js';
+export { actions } from './actions.js';
+export { agreements } from './agreements.js';
+export { messages } from './messages.js';
+export { events } from './events.js';

--- a/src/db/schema/messages.ts
+++ b/src/db/schema/messages.ts
@@ -1,0 +1,14 @@
+import { pgTable, text, integer, boolean } from 'drizzle-orm/pg-core';
+import { worlds } from './worlds.js';
+import { colonies } from './colonies.js';
+
+export const messages = pgTable('messages', {
+  id: text('id').primaryKey(),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  fromColony: text('from_colony').notNull().references(() => colonies.id),
+  toColony: text('to_colony').notNull().references(() => colonies.id),
+  sentAtTick: integer('sent_at_tick').notNull(),
+  deliveredAtTick: integer('delivered_at_tick').notNull(),
+  content: text('content').notNull(),
+  read: boolean('read').notNull().default(false),
+});

--- a/src/db/schema/settlements.ts
+++ b/src/db/schema/settlements.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, integer, jsonb } from 'drizzle-orm/pg-core';
+import { colonies } from './colonies.js';
+import { worlds } from './worlds.js';
+
+export const settlements = pgTable('settlements', {
+  id: text('id').primaryKey(),
+  colonyId: text('colony_id').notNull().references(() => colonies.id),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  name: text('name').notNull(),
+  hexX: integer('hex_x').notNull(),
+  hexY: integer('hex_y').notNull(),
+  tier: text('tier').notNull().default('outpost'), // outpost | town | city
+  buildings: jsonb('buildings').notNull().default([]),
+  buildQueue: jsonb('build_queue').notNull().default([]),
+  loyalty: integer('loyalty').notNull().default(100),
+  population: integer('population').notNull().default(10),
+});

--- a/src/db/schema/units.ts
+++ b/src/db/schema/units.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, integer, real, jsonb, index } from 'drizzle-orm/pg-core';
+import { colonies } from './colonies.js';
+import { worlds } from './worlds.js';
+
+export const units = pgTable('units', {
+  id: text('id').primaryKey(),
+  colonyId: text('colony_id').notNull().references(() => colonies.id),
+  worldId: text('world_id').notNull().references(() => worlds.id),
+  type: text('type').notNull(), // scout | militia | soldier | siege | settler
+  hexX: integer('hex_x').notNull(),
+  hexY: integer('hex_y').notNull(),
+  health: integer('health').notNull().default(100),
+  morale: real('morale').notNull().default(1.0),
+  movementQueue: jsonb('movement_queue').notNull().default([]),
+}, (table) => [
+  index('idx_units_world_colony').on(table.worldId, table.colonyId),
+]);

--- a/src/db/schema/worlds.ts
+++ b/src/db/schema/worlds.ts
@@ -1,0 +1,13 @@
+import { pgTable, text, integer, timestamp } from 'drizzle-orm/pg-core';
+
+export const worlds = pgTable('worlds', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  tickRate: integer('tick_rate').notNull().default(300000), // 5 min in ms
+  currentTick: integer('current_tick').notNull().default(0),
+  mapSeed: integer('map_seed').notNull(),
+  status: text('status').notNull().default('open'), // open | running | full | ended
+  mapRadius: integer('map_radius').notNull().default(50),
+  maxColonies: integer('max_colonies').notNull().default(8),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});


### PR DESCRIPTION
## Summary

Defines the complete database schema for RoboColony MVP using Drizzle ORM.

## Tables (9)

| Table | Purpose | Key Columns |
|-------|---------|------------|
| `worlds` | Game worlds | id, tick, status, map_seed, map_radius |
| `hexes` | Hex map tiles | (world_id, x, y) PK, terrain, resources JSONB |
| `colonies` | Player colonies | api_key_hash, resources JSONB, legacy_score |
| `settlements` | Outposts/towns/cities | tier, buildings JSONB, build_queue JSONB |
| `units` | Military units | type, health, morale, movement_queue JSONB |
| `actions` | Queued player actions | tick, type, params JSONB, status |
| `agreements` | Diplomatic agreements | type, terms JSONB, proposed/accepted tick |
| `messages` | Inter-colony messages | from/to colony, content, read |
| `events` | Game events (public + private) | public flag, visibility TEXT[], data JSONB |

## Indexes
- `idx_events_world_tick` — events by world + tick
- `idx_events_public` — public events by world + tick
- `idx_actions_world_tick` — actions by world + tick + status
- `idx_units_world_colony` — units by world + colony

## Tests
- Schema compilation test for all 9 tables
- Column presence verification for every table

Closes #2