### PR TITLE
feat: idle unit tracking and warning events (#60)

### DIFF
--- a/src/db/schema/units.ts
+++ b/src/db/schema/units.ts
@@ -12,6 +12,7 @@ export const units = pgTable('units', {
   health: integer('health').notNull().default(100),
   morale: real('morale').notNull().default(1.0),
   movementQueue: jsonb('movement_queue').notNull().default([]),
+  idleTicks: integer('idle_ticks').notNull().default(0),
 }, (table) => [
   index('idx_units_world_colony').on(table.worldId, table.colonyId),
 ]);

--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -37,6 +37,7 @@ import {
   TIER_ORDER,
   MAX_POPULATION,
   POP_GROWTH_PER_FOOD,
+  IDLE_WARNING_TICKS,
   type Colony,
   type Settlement,
   type Unit,
@@ -2577,3 +2578,118 @@ describe('upgrade_building in resolveTick (integration)', () => {
 });
 
 
+
+
+
+describe('Idle unit tracking', () => {
+  it('increments idleTicks for units with no movement and no actions', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({ id: 'scout-1', type: 'scout', idleTicks: 0 });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, []);
+
+    const updatedUnit = result.units.find(u => u.id === 'scout-1')!;
+    expect(updatedUnit.idleTicks).toBe(1);
+  });
+
+  it('resets idleTicks when unit receives a move action', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({ id: 'scout-1', type: 'scout', idleTicks: 2 });
+    const hexes = makeHexRing(0, 0);
+
+    const moveAction: QueuedAction = {
+      id: 'action-1',
+      colonyId: 'colony-1',
+      type: 'move_unit',
+      params: { unitId: 'scout-1', targetX: 1, targetY: 0 },
+    };
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, [moveAction]);
+
+    const updatedUnit = result.units.find(u => u.id === 'scout-1')!;
+    expect(updatedUnit.idleTicks).toBe(0);
+  });
+
+  it('resets idleTicks when unit has a movement queue and moves', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({
+      id: 'scout-1',
+      type: 'scout',
+      idleTicks: 5,
+      movementQueue: [{ q: 1, r: 0 }],
+    });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, []);
+
+    const updatedUnit = result.units.find(u => u.id === 'scout-1')!;
+    expect(updatedUnit.idleTicks).toBe(0);
+  });
+
+  it('emits unit_idle event when idleTicks reaches 3', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({ id: 'scout-1', type: 'scout', idleTicks: 2 });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, []);
+
+    const idleEvent = result.events.find(e => e.type === 'unit_idle');
+    expect(idleEvent).toBeDefined();
+    expect(idleEvent!.colonyId).toBe('colony-1');
+    expect(idleEvent!.unitId).toBe('scout-1');
+    expect(idleEvent!.data.unitType).toBe('scout');
+    expect(idleEvent!.data.idleTicks).toBe(3);
+  });
+
+  it('does not emit unit_idle event before reaching threshold', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({ id: 'scout-1', type: 'scout', idleTicks: 0 });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, []);
+
+    const idleEvent = result.events.find(e => e.type === 'unit_idle');
+    expect(idleEvent).toBeUndefined();
+  });
+
+  it('does not re-emit unit_idle event after threshold (only fires at exactly 3)', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ buildings: [{ type: 'farm', level: 1 }] });
+    const unit = makeUnit({ id: 'scout-1', type: 'scout', idleTicks: 3 });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [unit], hexes, []);
+
+    const idleEvent = result.events.find(e => e.type === 'unit_idle');
+    expect(idleEvent).toBeUndefined();
+    const updatedUnit = result.units.find(u => u.id === 'scout-1')!;
+    expect(updatedUnit.idleTicks).toBe(4);
+  });
+
+  it('newly trained units start with idleTicks 0', () => {
+    const colony = makeColony({ resources: { food: 200, timber: 100, stone: 50, iron: 20, influence: 50 } });
+    const settlement = makeSettlement({
+      buildings: [{ type: 'farm', level: 1 }, { type: 'barracks', level: 1 }],
+    });
+    const hexes = makeHexRing(0, 0);
+
+    const trainAction: QueuedAction = {
+      id: 'action-1',
+      colonyId: 'colony-1',
+      type: 'train_unit',
+      params: { settlementId: 'settlement-1', unitType: 'scout' },
+    };
+
+    const result = resolveTick([colony], [settlement], [], hexes, [trainAction]);
+
+    const trainedUnit = result.units.find(u => u.type === 'scout');
+    expect(trainedUnit).toBeDefined();
+    expect(trainedUnit!.idleTicks).toBe(0);
+  });
+});

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -22,6 +22,7 @@ const PUBLIC_EVENT_TYPES = new Set([
   'settlement_upgraded',
   'combat',
   'shortage',
+  'unit_idle',
 ]);
 
 /**
@@ -63,6 +64,11 @@ function buildPublicData(event: { type: string; colonyId?: string; data: Record<
       return {
         resource: event.data.resource,
         deficit: event.data.deficit,
+      };
+    case 'unit_idle':
+      return {
+        unitType: event.data.unitType,
+        idleTicks: event.data.idleTicks,
       };
     default:
       return null;
@@ -206,6 +212,7 @@ export class TickScheduler {
         health: u.health,
         morale: u.morale,
         movementQueue: (u.movementQueue ?? []) as Unit['movementQueue'],
+        idleTicks: u.idleTicks ?? 0,
       }));
 
       const hexes: HexTileState[] = dbHexes.map(h => ({
@@ -285,6 +292,7 @@ export class TickScheduler {
                 hexX: unit.hexX,
                 hexY: unit.hexY,
                 movementQueue: unit.movementQueue ?? [],
+                idleTicks: unit.idleTicks ?? 0,
               })
               .where(eq(schema.units.id, unit.id));
           } else {
@@ -299,6 +307,7 @@ export class TickScheduler {
               health: unit.health,
               morale: unit.morale,
               movementQueue: unit.movementQueue ?? [],
+              idleTicks: unit.idleTicks ?? 0,
             });
           }
         }
@@ -354,6 +363,7 @@ export class TickScheduler {
     }
   }
 }
+
 
 
 

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -68,6 +68,7 @@ export interface Unit {
   health: number;
   morale: number;
   movementQueue?: HexCoord[];
+  idleTicks?: number;
 }
 
 export type UnitType = 'scout' | 'militia' | 'soldier' | 'siege' | 'settler';
@@ -222,6 +223,9 @@ export const MAX_DEFICIT_MULTIPLIER = 3.0;
 
 /** Morale recovery per tick when food is positive */
 export const MORALE_RECOVERY_RATE = 0.10;
+
+/** Ticks of inactivity before emitting idle unit warning */
+export const IDLE_WARNING_TICKS = 3;
 
 /** Resource cost to found a new settlement */
 export const FOUNDING_COST: Partial<Resources> = {
@@ -1796,6 +1800,50 @@ export function resolveTick(
     }
   }
 
+  // --- Idle unit tracking ---
+  // A unit is "active" if it moved, has a movement queue, or received an action this tick.
+  const unitActionTargets = new Set<string>();
+  for (const action of actions) {
+    const unitId = action.params.unitId as string | undefined;
+    if (unitId) unitActionTargets.add(unitId);
+  }
+
+  // Newly trained units (not in unitPositionsBefore) start at 0
+  for (const unit of updatedUnits) {
+    if (desertedUnitIds.includes(unit.id)) continue;
+
+    const isNewUnit = !unitPositionsBefore.has(unit.id);
+    if (isNewUnit) {
+      unit.idleTicks = 0;
+      continue;
+    }
+
+    const before = unitPositionsBefore.get(unit.id)!;
+    const moved = before.x !== unit.hexX || before.y !== unit.hexY;
+    const hasQueue = unit.movementQueue && unit.movementQueue.length > 0;
+    const hadAction = unitActionTargets.has(unit.id);
+
+    if (moved || hasQueue || hadAction) {
+      unit.idleTicks = 0;
+    } else {
+      unit.idleTicks = (unit.idleTicks ?? 0) + 1;
+
+      if (unit.idleTicks === IDLE_WARNING_TICKS) {
+        events.push({
+          type: 'unit_idle',
+          colonyId: unit.colonyId,
+          unitId: unit.id,
+          data: {
+            unitType: unit.type,
+            hexX: unit.hexX,
+            hexY: unit.hexY,
+            idleTicks: unit.idleTicks,
+          },
+        });
+      }
+    }
+  }
+
   // Remove deserted units
   const survivingUnits = updatedUnits.filter(u => !desertedUnitIds.includes(u.id));
 
@@ -1809,6 +1857,7 @@ export function resolveTick(
     fogReveals,
   };
 }
+
 
 
 


### PR DESCRIPTION
## Summary

Implements idle unit event tracking from issue #60. When a unit has no movement queue and receives no actions for 3 consecutive ticks, the engine emits a `unit_idle` event visible to the owning colony.

## Changes

### `src/engine/tick.ts`
- Added `idleTicks?: number` to `Unit` interface
- Added `IDLE_WARNING_TICKS = 3` constant
- Added idle tracking logic after all tick phases:
  - Units that moved, have a queue, or received an action → `idleTicks = 0`
  - Idle units → `idleTicks++`
  - Newly trained units start at `idleTicks = 0`
  - Emits `unit_idle` event exactly when `idleTicks === 3` (one-shot, not every tick)

### `src/db/schema/units.ts`
- Added `idleTicks` column (`integer`, default `0`)
- Schema push will auto-add the column on deploy

### `src/engine/scheduler.ts`
- Loads `idleTicks` from DB when mapping units
- Persists `idleTicks` on unit updates and inserts
- Added `unit_idle` to public event types with public data builder

### `src/engine/__tests__/tick.test.ts`
- 7 new tests covering:
  - Idle tick increment for inactive units
  - Reset on move action
  - Reset when unit has movement queue
  - Event emission at threshold (exactly 3)
  - No event before threshold
  - No re-emission after threshold
  - Newly trained units start at 0

## Event Format
```json
{
  "type": "unit_idle",
  "colonyId": "col_xxx",
  "unitId": "unit_xxx",
  "data": {
    "unitType": "scout",
    "hexX": 34,
    "hexY": -28,
    "idleTicks": 3
  }
}
```

Closes #60 (idle unit warning).