### PR TITLE
feat: Settlement capture when garrison destroyed + loyalty system (#86)

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -50,6 +50,14 @@ import {
   IDLE_WARNING_TICKS,
   DEMOLISH_REFUND_RATE,
   DECAY_CHANCE_PER_BUILDING,
+  BUILDING_SLOTS,
+  resolveSettlementCapture,
+  CAPTURED_LOYALTY,
+  LOYALTY_GAIN_PER_TICK,
+  LOYALTY_LOSS_PER_TICK,
+  LOYALTY_PRODUCTION_THRESHOLD,
+  LOYALTY_MAX,
+  SCORE_SETTLEMENT_CAPTURED,
   type Colony,
   type Settlement,
   type Unit,
@@ -3282,6 +3290,162 @@ describe('combat integration with resolveTick', () => {
     expect(soldier!.hexY).toBe(0);
     // Settler should be dead
     expect(result.units.find(u => u.id === 'u2')).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Settlement Capture
+// =============================================================================
+
+describe('resolveSettlementCapture', () => {
+  it('captures settlement when enemy units present and no defenders', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0, tier: 'town', population: 40, loyalty: 100 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+
+    expect(result.settlements[0].colonyId).toBe('c2');
+    expect(result.settlements[0].tier).toBe('outpost'); // town → outpost
+    expect(result.settlements[0].population).toBe(20); // 50% of 40
+    expect(result.settlements[0].loyalty).toBe(CAPTURED_LOYALTY);
+    expect(result.settlements[0].buildQueue).toEqual([]);
+    expect(result.events).toHaveLength(2); // captured + lost
+    expect(result.events[0].type).toBe('settlement_captured');
+    expect(result.events[1].type).toBe('settlement_lost');
+  });
+
+  it('does not capture when owner has defenders', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c1', type: 'militia', hexX: 0, hexY: 0 }),
+      makeUnit({ id: 'u2', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].colonyId).toBe('c1');
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('does not capture when no enemy units present', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c1', type: 'militia', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].colonyId).toBe('c1');
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('demotes city to town on capture', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0, tier: 'city', population: 100 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].tier).toBe('town');
+    expect(result.settlements[0].population).toBe(50);
+  });
+
+  it('outpost stays outpost on capture', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0, tier: 'outpost', population: 20 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].tier).toBe('outpost');
+    expect(result.settlements[0].population).toBe(10);
+  });
+
+  it('cancels build queue on capture', () => {
+    const settlements = [
+      makeSettlement({
+        id: 's1', colonyId: 'c1', hexX: 0, hexY: 0,
+        buildQueue: [{ type: 'farm', ticksRemaining: 2 }],
+      }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].buildQueue).toEqual([]);
+  });
+
+  it('picks colony with most units when multiple attackers', () => {
+    const settlements = [
+      makeSettlement({ id: 's1', colonyId: 'c1', hexX: 0, hexY: 0 }),
+    ];
+    const units = [
+      makeUnit({ id: 'u1', colonyId: 'c2', type: 'soldier', hexX: 0, hexY: 0 }),
+      makeUnit({ id: 'u2', colonyId: 'c3', type: 'soldier', hexX: 0, hexY: 0 }),
+      makeUnit({ id: 'u3', colonyId: 'c3', type: 'militia', hexX: 0, hexY: 0 }),
+    ];
+
+    const result = resolveSettlementCapture(settlements, units);
+    expect(result.settlements[0].colonyId).toBe('c3'); // c3 has 2 units vs c2's 1
+  });
+});
+
+describe('loyalty system in resolveTick', () => {
+  it('loyalty affects production when below threshold', () => {
+    const colonies = [makeColony({ id: 'c1', resources: { food: 100, timber: 100, stone: 100, iron: 100, influence: 50 } })];
+    const settlements = [
+      makeSettlement({
+        id: 's1', colonyId: 'c1', hexX: 0, hexY: 0,
+        loyalty: 25, // 50% production
+        buildings: [{ type: 'farm', level: 1 }],
+        population: 10,
+      }),
+    ];
+    const units: Unit[] = [];
+    const hexes = makeHexRing(0, 0);
+    const actions: QueuedAction[] = [];
+
+    const result = resolveTick(colonies, settlements, units, hexes, actions);
+
+    // Find production event
+    const prodEvent = result.events.find(e => e.type === 'production');
+    expect(prodEvent).toBeDefined();
+    const data = prodEvent!.data as any;
+    expect(data.settlements[0].loyalty).toBe(25);
+  });
+
+  it('loyalty increases with positive food', () => {
+    const colonies = [makeColony({
+      id: 'c1',
+      resources: { food: 200, timber: 200, stone: 200, iron: 200, influence: 50 },
+    })];
+    const settlements = [
+      makeSettlement({
+        id: 's1', colonyId: 'c1', hexX: 0, hexY: 0,
+        loyalty: 25,
+        buildings: [{ type: 'farm', level: 3 }],
+        population: 5,
+      }),
+    ];
+    const units: Unit[] = [];
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick(colonies, settlements, units, hexes, []);
+
+    // Loyalty should have increased by LOYALTY_GAIN_PER_TICK
+    const settlement = result.settlements.find(s => s.id === 's1');
+    expect(settlement!.loyalty).toBe(25 + LOYALTY_GAIN_PER_TICK);
   });
 });
 

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -33,6 +33,7 @@ const PUBLIC_EVENT_TYPES = new Set([
   'combat_resolved',
   'unit_destroyed',
   'shortage',
+  'settlement_captured',
 ]);
 
 /**
@@ -87,6 +88,12 @@ function buildPublicData(event: { type: string; colonyId?: string; data: Record<
       return {
         unitType: event.data.unitType,
         cause: event.data.cause || 'combat',
+      };
+    case 'settlement_captured':
+      return {
+        name: event.data.name,
+        previousTier: event.data.previousTier,
+        newTier: event.data.newTier,
       };
     default:
       return null;

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -241,6 +241,24 @@ export const SCORE_UPGRADE_CITY = 250;
 export const SCORE_BUILDING_BUILT = 25;
 export const SCORE_UNIT_TRAINED = 10;
 export const SCORE_COMBAT_VICTORY = 100;
+export const SCORE_SETTLEMENT_CAPTURED = 200;
+
+// --- Settlement Capture Constants ---
+
+/** Loyalty value for a newly captured settlement */
+export const CAPTURED_LOYALTY = 25;
+
+/** Loyalty gain per tick when colony has positive net food */
+export const LOYALTY_GAIN_PER_TICK = 2;
+
+/** Loyalty loss per tick when colony has food deficit */
+export const LOYALTY_LOSS_PER_TICK = 5;
+
+/** Loyalty threshold below which production is reduced */
+export const LOYALTY_PRODUCTION_THRESHOLD = 50;
+
+/** Maximum loyalty value */
+export const LOYALTY_MAX = 100;
 
 /** Morale recovery per tick when food is positive */
 export const MORALE_RECOVERY_RATE = 0.10;
@@ -1871,6 +1889,124 @@ export function resolveCombat(
   };
 }
 
+// --- Settlement Capture Resolution ---
+
+export interface CaptureResult {
+  settlements: Settlement[];
+  events: TickEvent[];
+}
+
+/**
+ * Resolve settlement capture after combat.
+ *
+ * For each settlement hex, check if:
+ * 1. There are no defending units (owner's units) on the hex
+ * 2. There ARE enemy units on the hex
+ * If so, the settlement is captured by the attacking colony.
+ *
+ * Capture penalties:
+ * - Tier drops one level (city→town, town→outpost; outpost stays outpost)
+ * - Population drops by 50%
+ * - Build queue is cancelled
+ * - Loyalty set to CAPTURED_LOYALTY (25)
+ */
+export function resolveSettlementCapture(
+  settlements: Settlement[],
+  units: Unit[],
+): CaptureResult {
+  const events: TickEvent[] = [];
+
+  // Build a map of units per hex grouped by colony
+  const hexColonyUnits = new Map<string, Map<string, Unit[]>>();
+  for (const unit of units) {
+    const key = hexKey(unit.hexX, unit.hexY);
+    if (!hexColonyUnits.has(key)) hexColonyUnits.set(key, new Map());
+    const colonyMap = hexColonyUnits.get(key)!;
+    if (!colonyMap.has(unit.colonyId)) colonyMap.set(unit.colonyId, []);
+    colonyMap.get(unit.colonyId)!.push(unit);
+  }
+
+  for (const settlement of settlements) {
+    const key = hexKey(settlement.hexX, settlement.hexY);
+    const coloniesOnHex = hexColonyUnits.get(key);
+    if (!coloniesOnHex) continue;
+
+    // Check if the settlement owner has any units on this hex
+    const ownerUnits = coloniesOnHex.get(settlement.colonyId);
+    if (ownerUnits && ownerUnits.length > 0) continue; // defenders present
+
+    // Check if any OTHER colony has units on this hex
+    let capturingColonyId: string | null = null;
+    let capturingUnitCount = 0;
+    for (const [colonyId, colonyUnits] of coloniesOnHex) {
+      if (colonyId === settlement.colonyId) continue;
+      // Pick the colony with the most units (in case of multi-party battle)
+      if (colonyUnits.length > capturingUnitCount) {
+        capturingColonyId = colonyId;
+        capturingUnitCount = colonyUnits.length;
+      }
+    }
+
+    if (!capturingColonyId) continue; // no enemy units present
+
+    // --- Capture the settlement ---
+    const previousOwner = settlement.colonyId;
+    const previousTier = settlement.tier;
+    const previousPopulation = settlement.population;
+
+    // Transfer ownership
+    settlement.colonyId = capturingColonyId;
+
+    // Tier demotion (city→town, town→outpost, outpost stays outpost)
+    if (settlement.tier === 'city') {
+      settlement.tier = 'town';
+    } else if (settlement.tier === 'town') {
+      settlement.tier = 'outpost';
+    }
+    // outpost stays outpost
+
+    // Population drops by 50%
+    settlement.population = Math.max(1, Math.floor(settlement.population * 0.5));
+
+    // Cancel all build queue items
+    settlement.buildQueue = [];
+
+    // Set loyalty to captured value
+    settlement.loyalty = CAPTURED_LOYALTY;
+
+    // Emit capture event (visible to all — public)
+    events.push({
+      type: 'settlement_captured',
+      colonyId: capturingColonyId,
+      settlementId: settlement.id,
+      data: {
+        name: settlement.name,
+        previousOwner,
+        newOwner: capturingColonyId,
+        previousTier,
+        newTier: settlement.tier,
+        previousPopulation,
+        newPopulation: settlement.population,
+        loyalty: settlement.loyalty,
+      },
+    });
+
+    // Also notify the previous owner
+    events.push({
+      type: 'settlement_lost',
+      colonyId: previousOwner,
+      settlementId: settlement.id,
+      data: {
+        name: settlement.name,
+        capturedBy: capturingColonyId,
+        previousTier,
+      },
+    });
+  }
+
+  return { settlements, events };
+}
+
 // --- Message Resolution ---
 
 /** Maximum messages a colony can send per tick */
@@ -2581,6 +2717,15 @@ export function resolveTick(
     }
   }
 
+  // --- Phase 0.3: Settlement capture (after combat) ---
+  // Check if any settlement hexes now have enemy units but no owner units.
+  {
+    const captureResult = resolveSettlementCapture(updatedSettlements, updatedUnits);
+    if (captureResult.events.length > 0) {
+      events.push(...captureResult.events);
+    }
+  }
+
   // --- Phase 0.5: Fog of war reveals for units that moved ---
   const movedUnits = updatedUnits.filter(u => {
     const before = unitPositionsBefore.get(u.id);
@@ -2721,8 +2866,14 @@ export function resolveTick(
       const production = calculateProduction(settlement, nearbyHexes);
       const upkeep = calculateBuildingUpkeep(settlement);
 
+      // Loyalty penalty: below threshold, reduce production by (threshold - loyalty)%
+      let loyaltyMultiplier = 1.0;
+      if (settlement.loyalty < LOYALTY_PRODUCTION_THRESHOLD) {
+        loyaltyMultiplier = settlement.loyalty / LOYALTY_PRODUCTION_THRESHOLD;
+      }
+
       for (const key of Object.keys(totalProduction) as (keyof Resources)[]) {
-        totalProduction[key] += (production[key] as number) ?? 0;
+        totalProduction[key] += ((production[key] as number) ?? 0) * loyaltyMultiplier;
         totalUpkeep[key] += (upkeep[key] as number) ?? 0;
       }
 
@@ -2857,11 +3008,67 @@ export function resolveTick(
           buildingSlots: { used: s.buildings.length + s.buildQueue.length, max: BUILDING_SLOTS[s.tier] ?? 4 },
           population: s.population,
           maxPopulation: MAX_POPULATION[s.tier] ?? 50,
+          loyalty: s.loyalty,
         })),
         resources: { ...colony.resources },
       },
     });
 
+
+    // --- Loyalty tick ---
+    // Captured settlements gain loyalty when colony has positive food, lose it on deficit
+    for (const settlement of mySettlements) {
+      if (settlement.loyalty < LOYALTY_MAX) {
+        if (net.food >= 0) {
+          const oldLoyalty = settlement.loyalty;
+          settlement.loyalty = Math.min(LOYALTY_MAX, settlement.loyalty + LOYALTY_GAIN_PER_TICK);
+          if (settlement.loyalty !== oldLoyalty) {
+            events.push({
+              type: 'loyalty_change',
+              colonyId: colony.id,
+              settlementId: settlement.id,
+              data: {
+                name: settlement.name,
+                previousLoyalty: oldLoyalty,
+                newLoyalty: settlement.loyalty,
+                reason: 'positive_food',
+              },
+            });
+          }
+        }
+      }
+      if (net.food < 0 && settlement.loyalty > 0) {
+        const oldLoyalty = settlement.loyalty;
+        settlement.loyalty = Math.max(0, settlement.loyalty - LOYALTY_LOSS_PER_TICK);
+        if (settlement.loyalty !== oldLoyalty) {
+          events.push({
+            type: 'loyalty_change',
+            colonyId: colony.id,
+            settlementId: settlement.id,
+            data: {
+              name: settlement.name,
+              previousLoyalty: oldLoyalty,
+              newLoyalty: settlement.loyalty,
+              reason: 'food_deficit',
+            },
+          });
+        }
+        // Settlement rebels if loyalty reaches 0
+        if (settlement.loyalty <= 0) {
+          events.push({
+            type: 'settlement_rebellion',
+            colonyId: colony.id,
+            settlementId: settlement.id,
+            data: {
+              name: settlement.name,
+              reason: 'loyalty_depleted',
+            },
+          });
+          // For now, rebellion means the settlement is abandoned (colonyId cleared would need a neutral state)
+          // TODO: Implement neutral/independent settlements
+        }
+      }
+    }
 
     // --- Population growth ---
     // +1 population per POP_GROWTH_PER_FOOD excess food, capped by tier max
@@ -3086,6 +3293,9 @@ export function resolveTick(
           break;
         case 'combat_resolved':
           if ((event.data as any)?.winner === colony.id) colony.legacyScore += SCORE_COMBAT_VICTORY;
+          break;
+        case 'settlement_captured':
+          colony.legacyScore += SCORE_SETTLEMENT_CAPTURED;
           break;
       }
     }


### PR DESCRIPTION
## Changes

### Settlement Capture (Phase 0.3)
After combat resolution, checks if any settlement hexes have:
- No defending units (owner has 0 units on hex)
- Enemy units present

If so, the settlement is captured:
- Ownership transfers to attacking colony (most units wins)
- Tier demoted one level (city→town, town→outpost)
- Population drops 50%
- Build queue cancelled
- Loyalty set to 25

### Loyalty System
- `+2 loyalty/tick` with positive net food
- `-5 loyalty/tick` with food deficit
- Below loyalty 50: production reduced by `(50 - loyalty)/50`
- At loyalty 0: rebellion event emitted
- Production event now includes `loyalty` per settlement

### Events & Scoring
- `settlement_captured` — public event (spectator feed)
- `settlement_lost` — private event for previous owner
- `loyalty_change` — private event on loyalty shifts
- `settlement_rebellion` — when loyalty hits 0
- Legacy score: +200 for capturing a settlement

### Tests
- 7 new test cases for resolveSettlementCapture
- 2 new test cases for loyalty system in resolveTick

Closes #86