### PR TITLE
fix: scout auto-explore oscillation + truncate user input in errors (#118, #120)

### DIFF
--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -446,6 +446,12 @@ const UNFOUNDABLE_TERRAIN = new Set(['ocean', 'mountains']);
 
 // --- Helpers ---
 
+/** Truncate user-supplied IDs in error messages to prevent log bloat */
+function truncId(id: string, maxLen = 50): string {
+  if (id.length <= maxLen) return id;
+  return id.substring(0, maxLen) + '…[truncated]';
+}
+
 function hexKey(x: number, y: number): string {
   return `${x},${y}`;
 }
@@ -517,7 +523,7 @@ export function resolveBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -527,7 +533,7 @@ export function resolveBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -583,7 +589,7 @@ export function resolveBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -733,7 +739,7 @@ export function resolveUpgradeBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -743,7 +749,7 @@ export function resolveUpgradeBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -797,7 +803,7 @@ export function resolveUpgradeBuilding(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -897,7 +903,7 @@ export function resolveDemolish(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -907,7 +913,7 @@ export function resolveDemolish(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -941,7 +947,7 @@ export function resolveDemolish(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -1064,7 +1070,7 @@ export function resolveFoundSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Unit ${unitId} not found`,
+        result: `Unit ${truncId(unitId)} not found`,
       });
       continue;
     }
@@ -1074,7 +1080,7 @@ export function resolveFoundSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Unit ${unitId} does not belong to colony ${action.colonyId}`,
+        result: `Unit ${truncId(unitId)} does not belong to this colony`,
       });
       continue;
     }
@@ -1149,7 +1155,7 @@ export function resolveFoundSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -1282,7 +1288,7 @@ export function resolveTrainUnit(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -1292,7 +1298,7 @@ export function resolveTrainUnit(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -1325,7 +1331,7 @@ export function resolveTrainUnit(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -1433,7 +1439,7 @@ export function resolveUpgradeSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -1443,7 +1449,7 @@ export function resolveUpgradeSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -1477,7 +1483,7 @@ export function resolveUpgradeSettlement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -1577,7 +1583,7 @@ export function resolveMovement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Unit ${unitId} not found`,
+        result: `Unit ${truncId(unitId)} not found`,
       });
       continue;
     }
@@ -1587,7 +1593,7 @@ export function resolveMovement(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Unit ${unitId} does not belong to colony ${action.colonyId}`,
+        result: `Unit ${truncId(unitId)} does not belong to this colony`,
       });
       continue;
     }
@@ -2280,7 +2286,7 @@ export function resolveConvertResources(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} not found`,
+        result: `Settlement ${truncId(settlementId)} not found`,
       });
       continue;
     }
@@ -2290,7 +2296,7 @@ export function resolveConvertResources(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Settlement ${settlementId} does not belong to colony ${action.colonyId}`,
+        result: `Settlement ${truncId(settlementId)} does not belong to this colony`,
       });
       continue;
     }
@@ -2359,7 +2365,7 @@ export function resolveConvertResources(
       actionResults.push({
         actionId: action.id,
         status: 'failed',
-        result: `Colony ${action.colonyId} not found`,
+        result: `Colony ${truncId(action.colonyId)} not found`,
       });
       continue;
     }
@@ -2520,25 +2526,29 @@ export function autoExploreIdleScouts(
 
     frontierCandidates.sort((a, b) => frontierScore(b) - frontierScore(a));
 
-    // Try pathfinding to top-scored candidates (try up to 15)
+    // Partition candidates: prefer those at distance >= 2 from the scout
+    // to prevent 1-hop oscillation (scout bounces between adjacent hexes).
+    const farCandidates = frontierCandidates.filter(c => hexDistance(scoutPos, c) >= 2);
+    const nearCandidates = frontierCandidates.filter(c => hexDistance(scoutPos, c) < 2);
+
+    // Try far candidates first (prevents oscillation)
     let bestPath: HexCoord[] | null = null;
     let bestTarget: HexCoord | null = null;
 
-    for (let i = 0; i < Math.min(frontierCandidates.length, 15); i++) {
-      const candidate = frontierCandidates[i];
+    for (let i = 0; i < Math.min(farCandidates.length, 15); i++) {
+      const candidate = farCandidates[i];
       const path = findPath(scoutPos, candidate, hexLookup);
-      // Require path length >= 2 to avoid 1-hop oscillation
-      if (path && path.length >= 2) {
+      if (path && path.length > 0) {
         bestPath = path;
         bestTarget = candidate;
         break;
       }
     }
 
-    // Fallback: if no path with length >= 2, accept any valid path
+    // Fallback: near candidates only if no far candidates have paths
     if (!bestPath) {
-      for (let i = 0; i < Math.min(frontierCandidates.length, 15); i++) {
-        const candidate = frontierCandidates[i];
+      for (let i = 0; i < Math.min(nearCandidates.length, 15); i++) {
+        const candidate = nearCandidates[i];
         const path = findPath(scoutPos, candidate, hexLookup);
         if (path && path.length > 0) {
           bestPath = path;

--- a/src/routes/actions.ts
+++ b/src/routes/actions.ts
@@ -95,6 +95,12 @@ const MAX_ACTIONS_PER_TICK = 10;
 const MAX_SETTLEMENT_NAME_LENGTH = 40;
 const MAX_MESSAGE_LENGTH = 500;
 
+/** Truncate user-supplied IDs in error messages to prevent log bloat */
+function truncId(id: string, maxLen = 50): string {
+  if (id.length <= maxLen) return id;
+  return id.substring(0, maxLen) + '…[truncated]';
+}
+
 // --- Sanitization ---
 
 /** Strip HTML tags from a string */
@@ -313,21 +319,21 @@ async function validateOwnership(
       .limit(1);
 
     if (unit.length === 0) {
-      return { valid: false, error: `Unit ${params.unitId} not found` };
+      return { valid: false, error: `Unit ${truncId(params.unitId as string)} not found` };
     }
     if (unit[0].colonyId !== colonyId) {
-      return { valid: false, error: `Unit ${params.unitId} does not belong to your colony` };
+      return { valid: false, error: `Unit ${truncId(params.unitId as string)} does not belong to your colony` };
     }
 
     // Type-specific checks
     if (action.type === 'found_settlement' && unit[0].type !== 'settler') {
-      return { valid: false, error: `Unit ${params.unitId} is a ${unit[0].type}, not a settler. Only settlers can found settlements.` };
+      return { valid: false, error: `Unit ${truncId(params.unitId as string)} is a ${unit[0].type}, not a settler. Only settlers can found settlements.` };
     }
     if (action.type === 'attack' && unit[0].type === 'settler') {
       return { valid: false, error: `Settlers cannot attack. Use military units (scout, militia, soldier, siege).` };
     }
     if (action.type === 'explore' && unit[0].type !== 'scout') {
-      return { valid: false, error: `Unit ${params.unitId} is a ${unit[0].type}, not a scout. Only scouts can use the explore action.` };
+      return { valid: false, error: `Unit ${truncId(params.unitId as string)} is a ${unit[0].type}, not a scout. Only scouts can use the explore action.` };
     }
   }
 
@@ -345,10 +351,10 @@ async function validateOwnership(
       .limit(1);
 
     if (settlement.length === 0) {
-      return { valid: false, error: `Settlement ${params.settlementId} not found` };
+      return { valid: false, error: `Settlement ${truncId(params.settlementId as string)} not found` };
     }
     if (settlement[0].colonyId !== colonyId) {
-      return { valid: false, error: `Settlement ${params.settlementId} does not belong to your colony` };
+      return { valid: false, error: `Settlement ${truncId(params.settlementId as string)} does not belong to your colony` };
     }
   }
 


### PR DESCRIPTION
Fixes #118 (scout oscillation) and #120 (error message truncation).

### Scout Oscillation Fix
Partitions frontier candidates by distance from scout:
- **Far candidates** (distance >= 2): tried first, prevents 1-hop bounce
- **Near candidates** (distance 1): fallback only when surrounded

This prevents the ping-pong pattern where a scout moves to an adjacent frontier hex, reveals it, then moves back because the original hex is now the nearest frontier.

### Error Message Truncation
Adds `truncId()` helper that caps user-supplied IDs at 50 chars in error messages. Applied to all unit, settlement, and colony lookup errors in both `tick.ts` and `actions.ts`.

Prevents log bloat and response amplification from oversized inputs.