### PR TITLE
Remove admin endpoints task from Phase 7

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -22,7 +22,6 @@ Live playtesting active — playtesters filing bugs, balance issues, and suggest
   - ✅ Deploy to Fly.io
   - ✅ Rate limiting
   - ✅ API documentation
-  - ⬜ #124 Admin endpoints (pause/resume, status dashboard)
 
 ## Last Cycle (2026-03-27 06:04 UTC)
 - **No open PRs** to review


### PR DESCRIPTION
Removed the admin endpoints task from Phase 7.

## What does this PR do?

Brief description of the change.

## Related issue

Closes #

## How to test

1. ...
2. ...

## Checklist

- [ ] Tests added/updated
- [ ] `npm test` passes
- [ ] No `any` types introduced
- [ ] Commit messages follow conventional commits
