### PR TITLE
chore: keep Fly deployment single-machine

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = "ams"
   force_https = true
   auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
 
 [[http_service.checks]]
   grace_period = "30s"


### PR DESCRIPTION
## What does this PR do?

Keeps Fly deploys single-machine for RoboColony's singleton scheduler workload.

Change:
- sets `min_machines_running = 0` in `fly.toml`

## Why this is needed

During the image-based migration, Fly created a second healthy app machine for HA. For RoboColony that means a second tick scheduler, which is not safe. This keeps future deploys from creating that extra always-on machine.

## How to test

1. Confirm `fly.toml` sets `min_machines_running = 0`
2. On the next Fly deploy, verify only one app machine remains active
