### PR TITLE
fix: stamp image builds with version metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --depot=false
+      - run: |
+          flyctl deploy --remote-only --depot=false \
+            --build-arg VCS_REF=${{ github.sha }} \
+            --build-arg BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@ RUN npm run build
 # Production stage
 FROM node:22-alpine
 WORKDIR /app
+ARG VCS_REF=dev
+ARG BUILD_TIMESTAMP=unknown
 COPY package.json package-lock.json* ./
 RUN npm install --omit=dev && npm cache clean --force
 COPY --from=builder /app/dist ./dist
 COPY web ./web
+RUN SHORT_SHA="$(printf '%.7s' "$VCS_REF")" && \
+    printf '{"sha":"%s","short":"%s","timestamp":"%s","message":""}\n' "$VCS_REF" "$SHORT_SHA" "$BUILD_TIMESTAMP" > version.json && \
+    cp version.json dist/version.json && \
+    cp version.json web/version.json
 EXPOSE 3000
 ENV NODE_ENV=production
 CMD ["node", "dist/server.js"]

--- a/scripts/deploy-robocolony.sh
+++ b/scripts/deploy-robocolony.sh
@@ -22,7 +22,11 @@ if [[ -z "$FLYCTL_BIN" && -x /opt/homebrew/bin/flyctl ]]; then
 fi
 
 echo "Deploying app '$APP' with image-based rollout..."
-"$FLYCTL_BIN" deploy --remote-only --depot=false -a "$APP"
+GIT_SHA="$(git rev-parse HEAD)"
+BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+"$FLYCTL_BIN" deploy --remote-only --depot=false -a "$APP" \
+  --build-arg "VCS_REF=$GIT_SHA" \
+  --build-arg "BUILD_TIMESTAMP=$BUILD_TIMESTAMP"
 
 echo "Waiting for public health..."
 for attempt in 1 2 3 4 5; do

--- a/src/routes/__tests__/health.test.ts
+++ b/src/routes/__tests__/health.test.ts
@@ -15,7 +15,7 @@ describe('Health endpoint', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ status: 'ok', version: 'dev' });
+    expect(response.json()).toEqual({ status: 'ok', version: expect.any(String) });
   });
 
   it('GET /health returns correct content-type', async () => {


### PR DESCRIPTION
## What does this PR do?

Stamps image-based builds with version metadata so `/health` and `/version` report the deployed git revision instead of `dev`.

Changes:
- generates `dist/version.json` and `web/version.json` inside the Docker image
- passes git SHA and build timestamp from the local deploy script
- passes git SHA and build timestamp from the GitHub deploy workflow
- loosens the health test to assert a string version instead of a hard-coded fallback

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run src/routes/__tests__/health.test.ts`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json`
3. Deploy and confirm `/health` no longer reports `dev`
