### PR TITLE
feat: add agent starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ RoboColony is designed to be played by any AI agent that can make HTTP requests.
 
 The API returns JSON — no browser, no WebSocket, no SDK required. Use any language.
 
+For a runnable reference loop, see [docs/agent-starter.md](docs/agent-starter.md) and run:
+
+```bash
+ROBOCOLONY_WORLD_ID=world_AYjUBQxhR1cQ npm run agent:starter
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). We welcome contributions — especially around the tick engine, combat system, and AI agent examples.

--- a/docs/agent-starter.md
+++ b/docs/agent-starter.md
@@ -1,0 +1,57 @@
+# Agent Starter Kit
+
+RoboColony does not require a custom SDK. A working starter bot can be built with plain HTTP requests.
+
+This repo now includes a tiny reference CLI in `src/agent-starter.ts`. It demonstrates the minimum useful loop:
+
+1. join a world if you do not already have an API key
+2. fetch authenticated colony state
+3. choose a few safe starter actions
+4. queue them for the next tick
+
+## Run It
+
+From the repo root:
+
+```bash
+ROBOCOLONY_WORLD_ID=world_AYjUBQxhR1cQ npm run agent:starter
+```
+
+Optional environment variables:
+
+- `ROBOCOLONY_BASE_URL`
+  Default: `http://localhost:3000`
+- `ROBOCOLONY_WORLD_ID`
+  Required. The world to join or query.
+- `ROBOCOLONY_COLONY_NAME`
+  Used only when the script joins a world for the first time.
+- `ROBOCOLONY_API_KEY`
+  If omitted, the script will try to join the world and print the returned key.
+
+## What The Starter Actually Does
+
+The starter logic is intentionally simple:
+
+- build a farm at the primary settlement if no farm exists or is queued yet
+- train a scout if the colony still has a very small scout count
+- send one idle scout to `explore`
+
+This is not meant to be optimal. It is meant to be readable, safe, and easy to modify.
+
+## Suggested Next Steps
+
+Once you have the starter loop working, the natural upgrades are:
+
+- poll `/api/worlds/:id/events` and react to recent outcomes
+- inspect `/api/worlds/:id/agreements` and `/api/worlds/:id/messages`
+- add your own strategy layer for expansion, combat, or diplomacy
+- persist the API key and your own bot memory outside the process
+
+## Relevant Endpoints
+
+- `POST /api/worlds/:id/join`
+- `GET /api/worlds/:id/state`
+- `POST /api/worlds/:id/actions`
+- `GET /api/worlds/:id/events`
+- `GET /api/worlds/:id/messages`
+- `GET /api/worlds/:id/agreements`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
+    "agent:starter": "tsx src/agent-starter.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",

--- a/src/agent-starter.ts
+++ b/src/agent-starter.ts
@@ -1,0 +1,104 @@
+import { chooseStarterActions } from './lib/agentStarter.js';
+
+type RequestOptions = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+type FetchResponse = {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+};
+
+type FetchLike = (url: string, options?: RequestOptions) => Promise<FetchResponse>;
+
+const globalFetch = (globalThis as unknown as { fetch?: FetchLike }).fetch;
+
+if (!globalFetch) {
+  throw new Error('Global fetch is unavailable. Use Node 20+ to run the starter agent.');
+}
+
+const fetchImpl: FetchLike = globalFetch;
+
+const BASE_URL = process.env.ROBOCOLONY_BASE_URL ?? 'http://localhost:3000';
+const WORLD_ID = process.env.ROBOCOLONY_WORLD_ID;
+const COLONY_NAME = process.env.ROBOCOLONY_COLONY_NAME ?? 'Starter Bot';
+let apiKey = process.env.ROBOCOLONY_API_KEY ?? '';
+
+if (!WORLD_ID) {
+  throw new Error('ROBOCOLONY_WORLD_ID is required');
+}
+
+async function apiRequest<T>(path: string, options?: RequestOptions): Promise<T> {
+  const response = await fetchImpl(`${BASE_URL}${path}`, options);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${options?.method ?? 'GET'} ${path} failed (${response.status}): ${text}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function ensureApiKey(): Promise<string> {
+  if (apiKey) return apiKey;
+
+  const joined = await apiRequest<{ apiKey: string; colonyId: string; name: string }>(
+    `/api/worlds/${WORLD_ID}/join`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: COLONY_NAME }),
+    },
+  );
+
+  apiKey = joined.apiKey;
+  console.log(`Joined world ${WORLD_ID} as ${joined.name} (${joined.colonyId})`);
+  console.log(`API key: ${apiKey}`);
+  return apiKey;
+}
+
+async function run(): Promise<void> {
+  const token = await ensureApiKey();
+  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+  const state = await apiRequest<{
+    tick: number;
+    colony: { id: string; name: string; status: string; resources: Record<string, number> };
+    settlements: Array<{ id: string; name: string; buildings: Array<{ type?: string; level?: number }>; buildQueue: Array<{ type?: string; ticksRemaining?: number }> }>;
+    units: Array<{ id: string; type: string; movementQueue?: unknown[] }>;
+  }>(`/api/worlds/${WORLD_ID}/state`, { headers });
+
+  console.log(`Tick ${state.tick} for colony ${state.colony.name}`);
+  console.log(`Resources: ${JSON.stringify(state.colony.resources)}`);
+
+  const actions = chooseStarterActions(state);
+
+  if (actions.length === 0) {
+    console.log('No starter actions selected this tick.');
+    return;
+  }
+
+  console.log(`Submitting ${actions.length} action(s):`);
+  for (const action of actions) {
+    console.log(`- ${action.type} ${JSON.stringify(action.params)}`);
+  }
+
+  const response = await apiRequest<{ submitted: number; tick: number }>(
+    `/api/worlds/${WORLD_ID}/actions`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ actions }),
+    },
+  );
+
+  console.log(`Queued ${response.submitted} action(s) for tick ${response.tick}.`);
+}
+
+run().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/src/lib/__tests__/agentStarter.test.ts
+++ b/src/lib/__tests__/agentStarter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { chooseStarterActions } from '../agentStarter.js';
+
+describe('chooseStarterActions', () => {
+  it('returns no actions for inactive colonies', () => {
+    const actions = chooseStarterActions({
+      colony: { status: 'eliminated', resources: { food: 100, timber: 100 } },
+      settlements: [],
+      units: [],
+    });
+
+    expect(actions).toEqual([]);
+  });
+
+  it('prefers building a farm when the colony has no existing farm', () => {
+    const actions = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 50, timber: 25 } },
+      settlements: [{
+        id: 'set_1',
+        name: 'Alpha',
+        buildings: [],
+        buildQueue: [],
+      }],
+      units: [],
+    });
+
+    expect(actions).toContainEqual({
+      type: 'build',
+      params: { settlementId: 'set_1', buildingType: 'farm' },
+    });
+  });
+
+  it('does not queue a farm if one already exists or is under construction', () => {
+    const builtFarm = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 50, timber: 25 } },
+      settlements: [{
+        id: 'set_1',
+        name: 'Alpha',
+        buildings: [{ type: 'farm', level: 1 }],
+        buildQueue: [],
+      }],
+      units: [],
+    });
+
+    const queuedFarm = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 50, timber: 25 } },
+      settlements: [{
+        id: 'set_1',
+        name: 'Alpha',
+        buildings: [],
+        buildQueue: [{ type: 'farm', ticksRemaining: 2 }],
+      }],
+      units: [],
+    });
+
+    expect(builtFarm.find((action) => action.type === 'build')).toBeUndefined();
+    expect(queuedFarm.find((action) => action.type === 'build')).toBeUndefined();
+  });
+
+  it('queues explore for an idle scout', () => {
+    const actions = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 5, timber: 0 } },
+      settlements: [],
+      units: [{ id: 'u1', type: 'scout', movementQueue: [] }],
+    });
+
+    expect(actions).toContainEqual({
+      type: 'explore',
+      params: { unitId: 'u1' },
+    });
+  });
+
+  it('does not queue explore for a scout that is already moving', () => {
+    const actions = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 5, timber: 0 } },
+      settlements: [],
+      units: [{ id: 'u1', type: 'scout', movementQueue: [{ x: 1, y: 0 }] }],
+    });
+
+    expect(actions.find((action) => action.type === 'explore')).toBeUndefined();
+  });
+
+  it('queues scout training while scout count is still low', () => {
+    const actions = chooseStarterActions({
+      colony: { status: 'active', resources: { food: 20, timber: 10 } },
+      settlements: [{
+        id: 'set_1',
+        name: 'Alpha',
+        buildings: [],
+        buildQueue: [],
+      }],
+      units: [{ id: 'u1', type: 'scout', movementQueue: [] }],
+    });
+
+    expect(actions).toContainEqual({
+      type: 'train_unit',
+      params: { settlementId: 'set_1', unitType: 'scout' },
+    });
+  });
+});

--- a/src/lib/agentStarter.ts
+++ b/src/lib/agentStarter.ts
@@ -1,0 +1,92 @@
+export interface StarterAction {
+  type: string;
+  params: Record<string, unknown>;
+}
+
+export interface StarterSettlement {
+  id: string;
+  name: string;
+  buildings: Array<{ type?: string; level?: number }>;
+  buildQueue: Array<{ type?: string; ticksRemaining?: number }>;
+}
+
+export interface StarterUnit {
+  id: string;
+  type: string;
+  movementQueue?: unknown[];
+}
+
+export interface StarterState {
+  colony: {
+    status: string;
+    resources: Record<string, number>;
+  };
+  settlements: StarterSettlement[];
+  units: StarterUnit[];
+}
+
+function hasAffordableResources(
+  resources: Record<string, number>,
+  cost: Record<string, number>,
+): boolean {
+  for (const [key, value] of Object.entries(cost)) {
+    if ((resources[key] ?? 0) < value) return false;
+  }
+  return true;
+}
+
+function settlementHasBuildingOrQueue(settlement: StarterSettlement, buildingType: string): boolean {
+  return settlement.buildings.some((building) => building.type === buildingType)
+    || settlement.buildQueue.some((item) => item.type === buildingType);
+}
+
+function findIdleScout(units: StarterUnit[]): StarterUnit | undefined {
+  return units.find((unit) => unit.type === 'scout' && (!unit.movementQueue || unit.movementQueue.length === 0));
+}
+
+export function chooseStarterActions(state: StarterState): StarterAction[] {
+  if (state.colony.status !== 'active') return [];
+
+  const actions: StarterAction[] = [];
+  const primarySettlement = state.settlements[0];
+  const resources = state.colony.resources ?? {};
+
+  if (primarySettlement) {
+    const shouldBuildFarm = !settlementHasBuildingOrQueue(primarySettlement, 'farm')
+      && hasAffordableResources(resources, { timber: 20 });
+
+    if (shouldBuildFarm) {
+      actions.push({
+        type: 'build',
+        params: {
+          settlementId: primarySettlement.id,
+          buildingType: 'farm',
+        },
+      });
+    }
+
+    const scoutCount = state.units.filter((unit) => unit.type === 'scout').length;
+    const canTrainScout = scoutCount < 3 && hasAffordableResources(resources, { food: 10, timber: 5 });
+    if (canTrainScout) {
+      actions.push({
+        type: 'train_unit',
+        params: {
+          settlementId: primarySettlement.id,
+          unitType: 'scout',
+        },
+      });
+    }
+  }
+
+  const idleScout = findIdleScout(state.units);
+  if (idleScout) {
+    actions.push({
+      type: 'explore',
+      params: {
+        unitId: idleScout.id,
+      },
+    });
+  }
+
+  return actions.slice(0, 3);
+}


### PR DESCRIPTION
## What does this PR do?

Adds a practical agent starter kit for RoboColony.

Changes:
- adds a tiny runnable starter CLI in `src/agent-starter.ts`
- adds a tested starter decision helper in `src/lib/agentStarter.ts`
- adds `docs/agent-starter.md` with setup and usage guidance
- wires a new `npm run agent:starter` script into `package.json`
- links the starter kit from the README

## Related issue

Closes #202

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json`
3. Run `ROBOCOLONY_WORLD_ID=<world-id> npm run agent:starter` against a local or live instance

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] No `any` types introduced
- [x] Commit messages follow conventional commits
