### PR TITLE
feat: add poi survey interactions

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -9,6 +9,7 @@ import {
   resolveUpgradeSettlement,
   resolveUpgradeBuilding,
   resolveDemolish,
+  resolvePoiSurvey,
   resolveCombat,
   buildingUpgradeCost,
   calculateProduction,
@@ -53,6 +54,9 @@ import {
   HEALING_PER_TICK,
   BARRACKS_HEALING_BONUS,
   NEWCOMER_PROTECTION_TICKS,
+  POI_SURVEY_INFLUENCE,
+  WATCHTOWER_SURVEY_REVEAL_RADIUS,
+  SACRED_GROVE_SURVEY_MORALE_BONUS,
   IDLE_WARNING_TICKS,
   DEMOLISH_REFUND_RATE,
   DECAY_CHANCE_PER_BUILDING,
@@ -289,6 +293,83 @@ describe('calculateProduction', () => {
     expect(production.food).toBe(0);
   });
 
+});
+
+describe('resolvePoiSurvey', () => {
+  it('surveys a watchtower, grants influence, and reveals nearby hexes', () => {
+    const colony = makeColony({ resources: { food: 100, timber: 50, stone: 30, iron: 10, influence: 0 } });
+    const scout = makeUnit({ type: 'scout', hexX: 0, hexY: 0 });
+    const hexes = makePlainGrid(WATCHTOWER_SURVEY_REVEAL_RADIUS + 1).map((hex) =>
+      hex.x === 0 && hex.y === 0
+        ? makeHex(0, 0, { poi: { type: 'watchtower', discoveredBy: colony.id, discoveredAtTick: 5 }, exploredBy: [colony.id] })
+        : makeHex(hex.x, hex.y),
+    );
+    const action = makeAction({
+      id: 'action-survey-1',
+      type: 'survey_poi',
+      params: { unitId: scout.id },
+    });
+
+    const result = resolvePoiSurvey([colony], [scout], hexes, [action], 6);
+    const centerHex = hexes.find((hex) => hex.x === 0 && hex.y === 0)!;
+    const revealedCount = hexes.filter((hex) => hex.exploredBy?.includes(colony.id)).length;
+
+    expect(result.actionResults).toContainEqual({
+      actionId: 'action-survey-1',
+      status: 'resolved',
+      result: 'Surveyed a watchtower and charted 18 nearby hexes.',
+    });
+    expect(colony.resources.influence).toBe(POI_SURVEY_INFLUENCE.watchtower);
+    expect(centerHex.poi?.surveyedBy).toBe(colony.id);
+    expect(centerHex.poi?.surveyedAtTick).toBe(6);
+    expect(revealedCount).toBeGreaterThan(1);
+    expect(result.events[0]?.type).toBe('poi_surveyed');
+  });
+
+  it('surveys a sacred grove and boosts nearby morale', () => {
+    const colony = makeColony({ resources: { food: 100, timber: 50, stone: 30, iron: 10, influence: 0 } });
+    const scout = makeUnit({ id: 'unit-scout', type: 'scout', hexX: 2, hexY: -1, morale: 0.6 });
+    const ally = makeUnit({ id: 'unit-ally', type: 'militia', hexX: 3, hexY: -1, morale: 0.7 });
+    const farAlly = makeUnit({ id: 'unit-far', type: 'soldier', hexX: 8, hexY: 0, morale: 0.4 });
+    const hexes = [
+      makeHex(2, -1, { poi: { type: 'sacred_grove', discoveredBy: colony.id, discoveredAtTick: 3 }, exploredBy: [colony.id] }),
+      makeHex(3, -1),
+      makeHex(8, 0),
+    ];
+    const action = makeAction({
+      id: 'action-survey-2',
+      type: 'survey_poi',
+      params: { unitId: scout.id },
+    });
+
+    const result = resolvePoiSurvey([colony], [scout, ally, farAlly], hexes, [action], 7);
+
+    expect(colony.resources.influence).toBe(POI_SURVEY_INFLUENCE.sacred_grove);
+    expect(scout.morale).toBeCloseTo(Math.min(1, 0.6 + SACRED_GROVE_SURVEY_MORALE_BONUS));
+    expect(ally.morale).toBeCloseTo(Math.min(1, 0.7 + SACRED_GROVE_SURVEY_MORALE_BONUS));
+    expect(farAlly.morale).toBe(0.4);
+    expect(result.events[0]?.data.affectedUnits).toBe(2);
+  });
+
+  it('fails if the colony has not discovered the poi yet', () => {
+    const colony = makeColony();
+    const scout = makeUnit({ type: 'scout' });
+    const hexes = [makeHex(0, 0, { poi: { type: 'ancient_ruins' } })];
+    const action = makeAction({
+      id: 'action-survey-3',
+      type: 'survey_poi',
+      params: { unitId: scout.id },
+    });
+
+    const result = resolvePoiSurvey([colony], [scout], hexes, [action], 10);
+
+    expect(result.actionResults).toContainEqual({
+      actionId: 'action-survey-3',
+      status: 'failed',
+      result: 'Your colony must discover a POI before surveying it',
+    });
+    expect(result.events).toHaveLength(0);
+  });
 });
 
 // --- calculateBuildingUpkeep ---

--- a/src/engine/mapgen.ts
+++ b/src/engine/mapgen.ts
@@ -26,6 +26,8 @@ export interface PoiData {
   type: PoiType;
   discoveredBy?: string;     // colony ID that first explored this hex
   discoveredAtTick?: number; // tick when discovered
+  surveyedBy?: string;       // colony ID that completed the POI interaction
+  surveyedAtTick?: number;   // tick when the POI interaction was completed
 }
 
 export interface HexTile {

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -37,6 +37,7 @@ const PUBLIC_EVENT_TYPES = new Set([
   'agreement_accepted',
   'agreement_broken',
   'nap_blocked_combat',
+  'poi_surveyed',
 ]);
 
 /**
@@ -114,6 +115,13 @@ function buildPublicData(event: { type: string; colonyId?: string; data: Record<
         hexX: event.data.hexX,
         hexY: event.data.hexY,
         reason: event.data.reason,
+      };
+    case 'poi_surveyed':
+      return {
+        poiType: event.data.poiType,
+        x: event.data.x,
+        y: event.data.y,
+        summary: event.data.summary,
       };
     default:
       return null;
@@ -788,7 +796,6 @@ export class TickScheduler {
     }
   }
 }
-
 
 
 

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -74,6 +74,8 @@ export interface PoiState {
   type: string;
   discoveredBy?: string;
   discoveredAtTick?: number;
+  surveyedBy?: string;
+  surveyedAtTick?: number;
 }
 
 export interface HexTileState {
@@ -197,6 +199,21 @@ export interface TickResult {
   newMessages: MessageRecord[];
   agreementMutations: AgreementMutation[];
 }
+
+export const POI_SURVEY_INFLUENCE: Record<string, number> = {
+  mineral_deposit: 10,
+  fertile_valley: 10,
+  ancient_forest: 10,
+  ancient_ruins: 15,
+  abandoned_cache: 12,
+  crystal_cavern: 15,
+  watchtower: 12,
+  sacred_grove: 12,
+};
+
+export const WATCHTOWER_SURVEY_REVEAL_RADIUS = 2;
+export const SACRED_GROVE_SURVEY_RANGE = 3;
+export const SACRED_GROVE_SURVEY_MORALE_BONUS = 0.1;
 
 // --- Constants ---
 
@@ -1169,6 +1186,156 @@ export function resolveDisband(
   const remainingUnits = units.filter(u => !disbandedUnitIds.has(u.id));
 
   return { units: remainingUnits, events, actionResults, disbandedUnitIds: [...disbandedUnitIds] };
+}
+
+export function resolvePoiSurvey(
+  colonies: Colony[],
+  units: Unit[],
+  hexes: HexTileState[],
+  actions: QueuedAction[],
+  currentTick: number,
+): { events: TickEvent[]; actionResults: ActionResult[] } {
+  const events: TickEvent[] = [];
+  const actionResults: ActionResult[] = [];
+  const colonyById = new Map(colonies.map(colony => [colony.id, colony]));
+  const unitById = new Map(units.map(unit => [unit.id, unit]));
+  const hexMap = new Map(hexes.map(hex => [hexKey(hex.x, hex.y), hex]));
+  const surveyedHexes = new Set<string>();
+
+  for (const action of actions.filter(a => a.type === 'survey_poi')) {
+    const unitId = action.params.unitId as string | undefined;
+    if (!unitId) {
+      actionResults.push({ actionId: action.id, status: 'failed', result: 'Missing unitId' });
+      continue;
+    }
+
+    const unit = unitById.get(unitId);
+    if (!unit) {
+      actionResults.push({ actionId: action.id, status: 'failed', result: `Unit ${unitId} not found` });
+      continue;
+    }
+    if (unit.type !== 'scout') {
+      actionResults.push({ actionId: action.id, status: 'failed', result: 'Only scouts can survey POIs' });
+      continue;
+    }
+
+    const hex = hexMap.get(hexKey(unit.hexX, unit.hexY));
+    if (!hex?.poi) {
+      actionResults.push({ actionId: action.id, status: 'failed', result: `No POI at (${unit.hexX}, ${unit.hexY})` });
+      continue;
+    }
+    if (hex.poi.discoveredBy !== unit.colonyId) {
+      actionResults.push({
+        actionId: action.id,
+        status: 'failed',
+        result: 'Your colony must discover a POI before surveying it',
+      });
+      continue;
+    }
+
+    const surveyKey = `${unit.hexX},${unit.hexY}`;
+    if (hex.poi.surveyedBy || surveyedHexes.has(surveyKey)) {
+      actionResults.push({
+        actionId: action.id,
+        status: 'failed',
+        result: `POI at (${unit.hexX}, ${unit.hexY}) has already been surveyed`,
+      });
+      continue;
+    }
+
+    hex.poi = {
+      ...hex.poi,
+      surveyedBy: unit.colonyId,
+      surveyedAtTick: currentTick,
+    };
+    surveyedHexes.add(surveyKey);
+
+    const colony = colonyById.get(unit.colonyId);
+    const influenceBonus = POI_SURVEY_INFLUENCE[hex.poi.type] ?? 10;
+    if (colony) {
+      colony.resources.influence += influenceBonus;
+    }
+
+    const eventData: Record<string, unknown> = {
+      poiType: hex.poi.type,
+      x: unit.hexX,
+      y: unit.hexY,
+      influenceBonus,
+      summary: '',
+    };
+
+    switch (hex.poi.type) {
+      case 'watchtower': {
+        const revealTargets = hexesWithinRadius(
+          { q: unit.hexX, r: unit.hexY },
+          WATCHTOWER_SURVEY_REVEAL_RADIUS,
+          new Set(hexMap.keys()),
+        );
+        let revealedCount = 0;
+        for (const coord of revealTargets) {
+          const targetHex = hexMap.get(hexKey(coord.q, coord.r));
+          if (!targetHex) continue;
+          const exploredBy = targetHex.exploredBy ?? [];
+          if (!exploredBy.includes(unit.colonyId)) {
+            targetHex.exploredBy = [...exploredBy, unit.colonyId];
+            revealedCount++;
+          }
+        }
+        eventData.revealedHexes = revealedCount;
+        eventData.summary = `Surveyed a watchtower and charted ${revealedCount} nearby hexes.`;
+        break;
+      }
+      case 'sacred_grove': {
+        let affectedUnits = 0;
+        for (const otherUnit of units) {
+          if (otherUnit.colonyId !== unit.colonyId) continue;
+          if (hexDistance({ q: unit.hexX, r: unit.hexY }, { q: otherUnit.hexX, r: otherUnit.hexY }) > SACRED_GROVE_SURVEY_RANGE) continue;
+          const before = otherUnit.morale;
+          otherUnit.morale = Math.min(1, otherUnit.morale + SACRED_GROVE_SURVEY_MORALE_BONUS);
+          if (otherUnit.morale > before) affectedUnits++;
+        }
+        eventData.moraleBonus = SACRED_GROVE_SURVEY_MORALE_BONUS;
+        eventData.affectedUnits = affectedUnits;
+        eventData.summary = `Surveyed a sacred grove and steadied ${affectedUnits} nearby units.`;
+        break;
+      }
+      case 'ancient_ruins':
+        eventData.summary = 'Surveyed ancient ruins and recovered strategic lore from the frontier.';
+        break;
+      case 'abandoned_cache':
+        eventData.summary = 'Surveyed an abandoned cache and mapped a reliable frontier resupply site.';
+        break;
+      case 'crystal_cavern':
+        eventData.summary = 'Surveyed a crystal cavern and recorded a rare mineral landmark.';
+        break;
+      case 'mineral_deposit':
+        eventData.summary = 'Surveyed a mineral deposit and marked it as a strategic extraction site.';
+        break;
+      case 'fertile_valley':
+        eventData.summary = 'Surveyed a fertile valley and charted a valuable frontier breadbasket.';
+        break;
+      case 'ancient_forest':
+        eventData.summary = 'Surveyed an ancient forest and logged a prime frontier timber reserve.';
+        break;
+      default:
+        eventData.summary = 'Surveyed a point of interest.';
+        break;
+    }
+
+    events.push({
+      type: 'poi_surveyed',
+      colonyId: unit.colonyId,
+      unitId: unit.id,
+      data: eventData,
+    });
+    actionResults.push({
+      actionId: action.id,
+      status: 'resolved',
+      result: eventData.summary as string,
+    });
+  }
+
+  return { events, actionResults };
 }
 
 /**
@@ -3620,21 +3787,21 @@ export function resolveTick(
     for (let i = 0; i < actions.length; i++) {
       const a = actions[i];
       const unitId = (a.params?.unitId as string) || null;
-      if (unitId && (a.type === 'move_unit' || a.type === 'attack' || a.type === 'explore')) {
+      if (unitId && (a.type === 'move_unit' || a.type === 'attack' || a.type === 'explore' || a.type === 'survey_poi')) {
         unitActions.set(unitId, i);
       }
     }
     for (let i = 0; i < actions.length; i++) {
       const a = actions[i];
       const unitId = (a.params?.unitId as string) || null;
-      if (unitId && (a.type === 'move_unit' || a.type === 'attack' || a.type === 'explore')) {
+      if (unitId && (a.type === 'move_unit' || a.type === 'attack' || a.type === 'explore' || a.type === 'survey_poi')) {
         // Reject movement for units that are being consumed by found_settlement or disband
         if (consumedUnitIds.has(unitId)) {
           const reason = actions.find(x => (x.type === 'found_settlement' || x.type === 'disband') && x.params?.unitId === unitId)?.type;
           actionResults.push({
             actionId: a.id,
             status: 'failed',
-            result: `Unit ${unitId} has a ${reason} action — movement rejected`,
+            result: `Unit ${unitId} has a ${reason} action — unit action rejected`,
           });
           continue;
         }
@@ -4072,6 +4239,14 @@ export function resolveTick(
     const convertResult = resolveConvertResources(updatedSettlements, updatedColonies, actions);
     events.push(...convertResult.events);
     actionResults.push(...convertResult.actionResults);
+  }
+
+  // --- Phase 1.96: Resolve POI survey actions ---
+  const surveyActions = actions.filter(a => a.type === 'survey_poi');
+  if (surveyActions.length > 0 && currentTick !== undefined) {
+    const surveyResult = resolvePoiSurvey(updatedColonies, updatedUnits, hexes, actions, currentTick);
+    events.push(...surveyResult.events);
+    actionResults.push(...surveyResult.actionResults);
   }
 
 

--- a/src/routes/__tests__/actions.test.ts
+++ b/src/routes/__tests__/actions.test.ts
@@ -7,6 +7,7 @@ const VALID_ACTION_TYPES: Record<string, string[]> = {
   'build': ['settlementId', 'buildingType'],
   'train_unit': ['settlementId', 'unitType'],
   'found_settlement': ['unitId', 'name'],
+  'survey_poi': ['unitId'],
   'demolish': ['settlementId', 'buildingType'],
   'upgrade_settlement': ['settlementId'],
 };
@@ -65,6 +66,14 @@ describe('Action validation', () => {
       const result = validateActionType({
         type: 'found_settlement',
         params: { unitId: 'unit_abc', name: 'New Town' },
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts valid survey_poi action', () => {
+      const result = validateActionType({
+        type: 'survey_poi',
+        params: { unitId: 'unit_abc' },
       });
       expect(result.valid).toBe(true);
     });
@@ -132,7 +141,7 @@ describe('Action validation', () => {
   describe('all action types have validation rules', () => {
     const expectedTypes = [
       'move_unit', 'build', 'train_unit',
-      'found_settlement', 'demolish', 'upgrade_settlement',
+      'found_settlement', 'survey_poi', 'demolish', 'upgrade_settlement',
     ];
 
     for (const type of expectedTypes) {

--- a/src/routes/__tests__/events.test.ts
+++ b/src/routes/__tests__/events.test.ts
@@ -285,5 +285,21 @@ describe('Event Feed', () => {
       };
       expect(desertionEvent.public).toBe(true);
     });
+
+    it('poi survey events can be exposed to spectators with public summaries', () => {
+      const surveyEvent = {
+        type: 'poi_surveyed',
+        public: true,
+        colonyId: 'col_a',
+        data: {
+          poiType: 'watchtower',
+          x: 4,
+          y: -2,
+          summary: 'Surveyed a watchtower and charted 13 nearby hexes.',
+        },
+      };
+      expect(surveyEvent.public).toBe(true);
+      expect(surveyEvent.data.poiType).toBe('watchtower');
+    });
   });
 });

--- a/src/routes/actions.ts
+++ b/src/routes/actions.ts
@@ -45,6 +45,7 @@ const VALID_ACTION_TYPES: Record<string, string[]> = {
   'attack': ['unitId', 'targetX', 'targetY'],
   'send_message': ['toColonyId', 'message'],
   'explore': ['unitId'],
+  'survey_poi': ['unitId'],
   'convert_resources': ['settlementId', 'fromResource', 'toResource', 'amount'],
   'research': ['techId'],
   'propose_agreement': ['targetColonyId', 'agreementType'],
@@ -66,6 +67,7 @@ const ALLOWED_PARAMS: Record<string, string[]> = {
   'attack': ['unitId', 'targetX', 'targetY'],
   'send_message': ['toColonyId', 'message'],
   'explore': ['unitId'],
+  'survey_poi': ['unitId'],
   'convert_resources': ['settlementId', 'fromResource', 'toResource', 'amount'],
   'research': ['techId'],
   'propose_agreement': ['targetColonyId', 'agreementType', 'terms'],
@@ -211,7 +213,7 @@ function validateActionParams(action: ActionInput, mapRadius: number): Validatio
   }
 
   // String ID validation for unit-based actions
-  if (['explore', 'found_settlement', 'disband'].includes(action.type)) {
+  if (['explore', 'survey_poi', 'found_settlement', 'disband'].includes(action.type)) {
     if (typeof p.unitId !== 'string' || p.unitId.length === 0) {
       return { valid: false, error: `'unitId' must be a non-empty string` };
     }
@@ -359,8 +361,8 @@ async function validateOwnership(
     if (action.type === 'attack' && unit[0].type === 'settler') {
       return { valid: false, error: `Settlers cannot attack. Use military units (scout, militia, soldier, siege).` };
     }
-    if (action.type === 'explore' && unit[0].type !== 'scout') {
-      return { valid: false, error: `Unit ${truncId(params.unitId as string)} is a ${unit[0].type}, not a scout. Only scouts can use the explore action.` };
+    if ((action.type === 'explore' || action.type === 'survey_poi') && unit[0].type !== 'scout') {
+      return { valid: false, error: `Unit ${truncId(params.unitId as string)} is a ${unit[0].type}, not a scout. Only scouts can use the ${action.type} action.` };
     }
   }
 
@@ -765,5 +767,4 @@ export async function actionRoutes(app: FastifyInstance) {
     return { cancelled: true, count: cancelledCount };
   });
 }
-
 

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -21,7 +21,7 @@ export interface VisibleHex {
   terrain: string;
   resources: Record<string, number>;
   settlementId: string | null;
-  poi?: { type: string; discoveredBy?: string; discoveredAtTick?: number } | null;
+  poi?: { type: string; discoveredBy?: string; discoveredAtTick?: number; surveyedBy?: string; surveyedAtTick?: number } | null;
 }
 
 /**

--- a/web/docs.html
+++ b/web/docs.html
@@ -241,6 +241,7 @@
         <tr><td><code>attack</code></td><td><code>unitId</code>, <code>targetX</code>, <code>targetY</code></td><td>Orders a military move into hostile territory</td></tr>
         <tr><td><code>send_message</code></td><td><code>toColonyId</code>, <code>message</code></td><td>Diplomatic message, max 500 chars</td></tr>
         <tr><td><code>explore</code></td><td><code>unitId</code></td><td>Scout-oriented frontier exploration order</td></tr>
+        <tr><td><code>survey_poi</code></td><td><code>unitId</code></td><td>Scout interaction for a discovered POI on the scout's current hex</td></tr>
         <tr><td><code>convert_resources</code></td><td><code>settlementId</code>, <code>fromResource</code>, <code>toResource</code>, <code>amount</code></td><td>Market conversion, max 200 per action</td></tr>
         <tr><td><code>research</code></td><td><code>techId</code></td><td>Current techs: <code>improved_agriculture</code>, <code>fortifications</code>, <code>advanced_scouting</code>, <code>steel_weapons</code>, <code>trade_routes</code>, <code>siege_engineering</code></td></tr>
         <tr><td><code>propose_agreement</code></td><td><code>targetColonyId</code>, <code>agreementType</code></td><td>Agreement types: <code>non_aggression</code>, <code>trade</code>, <code>alliance</code>, <code>ceasefire</code></td></tr>

--- a/web/index.html
+++ b/web/index.html
@@ -705,6 +705,7 @@
                 <tr><td><code>move_unit</code></td><td>unitId, targetX, targetY</td><td>Move a unit to a hex</td></tr>
                 <tr><td><code>attack</code></td><td>unitId, targetX, targetY</td><td>Send a unit to attack a hex</td></tr>
                 <tr><td><code>explore</code></td><td>unitId</td><td>Send a scout to the nearest unexplored frontier hex</td></tr>
+                <tr><td><code>survey_poi</code></td><td>unitId</td><td>Have a scout survey a discovered POI on its current hex</td></tr>
                 <tr><td><code>upgrade_building</code></td><td>settlementId, buildingType</td><td>Upgrade a building to next level</td></tr>
                 <tr><td><code>upgrade_settlement</code></td><td>settlementId</td><td>Upgrade settlement tier from outpost to town to city</td></tr>
                 <tr><td><code>disband</code></td><td>unitId</td><td>Disband one of your units outside of combat</td></tr>


### PR DESCRIPTION
## What does this PR do?

Adds a first explicit POI interaction layer for scouts.

Changes:
- adds a new survey_poi action for scouts standing on a discovered POI
- marks POIs as surveyed in visible state so agents can avoid duplicate interactions
- grants one-time influence rewards for surveying POIs
- gives watchtowers an active reveal effect and sacred groves a nearby morale boost
- publishes poi_surveyed events to the public feed so exploration creates visible frontier stories
- updates website docs to include the new action

## Related issue

Closes #203

## How to test

1. Run /opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run
2. Run /opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit
3. Queue survey_poi for a scout on a discovered POI and confirm the effect and public event appear

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits