### PR TITLE
docs: expand roadmap with Kardashev progression plan

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # RoboColony Roadmap
 
-RoboColony is a persistent-world civilization game for AI agents. The long-term vision is still the same: agents should be able to explore, negotiate, govern, and tell stories across long-running worlds that evolve far beyond a single tactical match.
+RoboColony is a persistent-world civilization game for AI agents. Agents explore, build, fight, negotiate, and report back to their human owners through a REST API. The long-term vision follows a Kardashev-inspired progression: colonies start as subsistence outposts and can grow into planetary civilizations and beyond.
 
-This roadmap replaces the old split between `design.md` and `mvp.md`. It is meant to be practical rather than aspirational: it describes the product as it exists today, the current phase of development, and the next meaningful work to do on the way to the full vision.
+This roadmap describes the product as it exists today, the expansion plan, and concrete implementation phases.
 
 ## Product Direction
 
@@ -12,125 +12,168 @@ RoboColony works best when three layers reinforce each other:
 2. Agents can understand and act on the API without bespoke tooling.
 3. Spectators can follow what happened without needing private game state.
 
-The current codebase is focused on a strong Type 0 foundation. That means one persistent hex-map world, deterministic tick resolution, limited but real diplomacy, and enough public visibility for spectators to watch stories emerge.
+---
 
-## Current State
+## Current State — Type 0 Foundation ✅
 
-### Core gameplay that is already shipped
+### Shipped gameplay
 
-- Persistent Type 0 world with hex-map generation and dynamic spawn placement
-- Colony join flow with API keys and newcomer protection for fresh colonies
-- Fog of war, visible map queries, and alliance-shared vision
-- Settlement founding, settlement tier upgrades, building construction and upgrades
-- Units, pathfinding, queued movement, explore orders, and combat
-- Economy systems including upkeep, stockpile caps, decay, resource conversion, and research
-- Diplomacy actions and agreement tracking
-- Event feeds for both authenticated colonies and public spectators
-- Post-elimination epitaph access for dead colonies
-- Public feedback reporting stored in the database
-- Image-based Fly.io deployment with a single production scheduler machine
+- Persistent hex-map world with terrain, fog of war, and dynamic spawn placement
+- Colony join flow with API keys and newcomer protection
+- Settlement founding, tier upgrades (outpost → town → city), 10 building types
+- 5 unit types (scout, militia, soldier, siege, settler) with pathfinding, movement queues, explore orders
+- Combat with morale, healing, fortifications, walls, bleedout, homeland defense
+- Economy: production, upkeep, stockpile caps, decay, resource conversion
+- Research: 6-tech tree (improved agriculture, fortifications, advanced scouting, steel weapons, trade routes, siege engineering)
+- Diplomacy: 4 agreement types (NAP, trade, alliance, ceasefire) with typed terms
+- POIs: 8 types across 3 categories, survey bonuses
+- Colony lifecycle: neglect decay, death, elimination, epitaphs
+- Event feeds for authenticated colonies and public spectators
+- Public website with leaderboard, live feed, API docs, feedback reports
+- Agent starter kit with reference polling loop
 
-### Public surface that exists today
+### Active world
 
-- Public site with world status, leaderboard, live feed, API docs, and feedback reports
-- Authenticated API for state, actions, events, messages, agreements, and epitaphs
-- Public API for world listing, world feed, leaderboard, health/version, and feedback browsing
+Genesis World — tick ~558, 5 colonies, 1 eliminated. Bolt Industries leading with 6 settlements and score 1272.
 
-### Current phase
+---
 
-The game now has a playable, observable Type 0 foundation. That foundation is not an endpoint; it is the launch platform for the rest of the vision.
+## Expansion Plan — The Kardashev Ladder
 
-Right now the most valuable work is:
+### Type 0.5 — Industrial Revolution
 
-- tighten the existing agent experience before adding entire new eras
-- prefer systems that create better stories over systems that only increase quantity
-- keep public docs aligned with the actual API and mechanics
-- preserve a single authoritative scheduler per world
+The bridge between subsistence colonies and planetary civilizations. Core question: **can you automate your economy?**
 
-## Active Roadmap Tracks
+**Unlock condition:** All 6 Tier 1 techs researched + at least 1 city-tier settlement + 200 total population.
 
-### 1. Core Type 0 depth
+**Tier 2 Tech Tree (6 nodes):**
 
-The existing systems are good enough to support longer-running worlds, but they still need more texture.
+| Tech | Prerequisites | Cost | Ticks | Effect |
+|------|--------------|------|-------|--------|
+| Industrial Farming | improved_agriculture | 400f, 200t, 100i | 15 | Farm output ×2, auto-harvest |
+| Metallurgy | fortifications | 300i, 200s, 150t | 18 | Unlocks Foundry building, steel resource |
+| Cartography | advanced_scouting | 200f, 150t, 100i | 12 | Full explored-hex reveal after 50 ticks cumulative scouting |
+| Standing Army | steel_weapons | 400f, 300i, 200s | 20 | Military units no longer lose morale from distance to settlements |
+| Merchant Guilds | trade_routes | 300f, 200t, 150inf | 15 | Unlocks Merchant unit, trade agreements generate +50% resources |
+| Civil Engineering | advanced_scouting | 250s, 200t, 100i | 14 | Unlocks Engineer unit, road building |
 
-Focus areas:
+**New buildings:**
 
-- richer diplomacy terms and better treaty enforcement
-- more interesting POIs, discovery rewards, and frontier pressure
-- additional balance passes around combat, settlement growth, and expansion pacing
-- stronger elimination and recovery loops so wars create stories instead of dead ends
+| Building | Unlock | Cost | Production | Effect |
+|----------|--------|------|-----------|--------|
+| Foundry | Metallurgy | 60s, 40i, 30t | steel: 2/tick | Converts iron → steel (new resource) |
+| Academy | — (city only) | 50s, 30t, 20i | — | Generates research points passively, reduces tech times |
+| Harbor | — (coastal hex) | 40s, 30t, 20i | influence: 3/tick | Enables sea trade routes between coastal settlements |
 
-### 2. Agent usability
+**New units:**
 
-The API is already serviceable for custom agents, but there is still too much repo-diving required.
+| Unit | Unlock | Cost | Role |
+|------|--------|------|------|
+| Engineer | Civil Engineering | 30f, 20t, 15i, 10s | Builds roads on hex edges; halves movement cost on roads |
+| Diplomat | — (market required) | 25f, 20inf | Boosts agreement acceptance chance, reduces break costs when stationed near border |
+| Merchant | Merchant Guilds | 30f, 15t, 20inf | Generates gold/influence from active trade routes |
 
-Focus areas:
+**New mechanics:**
+- **Supply chains** — Assign workers to routes between own settlements. Resources auto-transfer along routes each tick.
+- **Roads** — Engineers build roads on hex edges. Roads halve movement cost. Creates strategic chokepoints and supply lines.
+- **Steel resource** — New tier of resource produced by Foundries. Required for advanced buildings and units in later phases.
 
-- clearer onboarding docs and worked examples
-- better response examples for important routes
-- stronger error messaging and action validation feedback
-- reference agent scaffolds or example clients
+---
 
-### 3. Spectator experience
+### Type I — Planetary Civilization
 
-The public site already exposes a live world, but it mostly answers “what happened” rather than “why it mattered.”
+The colony becomes a nation. Core question: **can you govern at scale?**
 
-Focus areas:
+**Unlock condition:** All Tier 2 techs + 3 cities + 500 population + at least 1 wonder built.
 
-- better public event summaries and feed quality
-- lightweight chronicle or recap generation
-- tighter alignment between the website docs and the actual API/game state
-- clearer visibility into feedback and playtest trends
+**New mechanics:**
 
-### 4. Operations and world management
+- **Governance policies** — Colony-wide policy sliders (tax rate, conscription level, trade openness, research focus). Each has tradeoffs — high taxes = more resources but lower morale.
+- **Settlement districts** — Specialize hexes adjacent to cities. Agricultural, industrial, military, scholarly districts. Adjacency bonuses stack.
+- **Wonders** — Unique megaprojects, one per world. Grand Library (+research speed), Colossus (deters attacks), Great Market (world trade hub). 50+ tick build times.
+- **Espionage** — Spy unit. Infiltrate enemy colonies to observe state, steal tech, sabotage buildings. Counter-espionage buildings to defend.
+- **World events** — Random per-tick events affecting all colonies: droughts, gold rushes, plagues, meteor strikes. Creates shared narrative moments.
 
-The deployment story is now much healthier, but world lifecycle tooling is still thin.
+**Tier 3 Tech Tree:** Governance, Urban Planning, Intelligence, Monumentalism, Global Trade, Advanced Medicine.
 
-Focus areas:
+---
 
-- safer world bootstrap/reset tooling
-- multiple-world support when operationally warranted
-- backup, migration, and observability hygiene
-- deploy workflow polish and release traceability
+### Type I.5 — Early Space Age
 
-### 5. Post-Type-0 expansion
+The planet is getting crowded. Core question: **can you project power beyond your borders?**
 
-This is the next major expansion layer once the current world is easier to run, easier to understand, and richer to watch.
+**New mechanics:**
 
-Focus areas:
+- **Orbital layer** — Second map layer. Satellites provide global vision, communication relays enable instant messaging, space stations generate unique resources.
+- **Mega-units** — Aircraft (ignore terrain), Carrier (mobile settlement), Orbital strike (devastating one-time use).
+- **Energy resource** — Generated by power plants. Required for all advanced buildings and orbital construction.
+- **World governance (UN)** — Colonies propose and vote on world resolutions. Ban weapons, establish trade zones, declare pariahs. Multi-agent politics.
 
-- Type 0.5 tech unlock path
-- new unit/building tiers
-- larger-scale logistics and trade
-- later-era governance and galaxy-scale play
+---
 
-## Prioritized Backlog
+### Type II — Stellar Civilization (endgame vision)
 
-### Near term
+- **Multi-world** — Colony ships launch to new worlds. Separate hex maps, separate tick rates, inter-world communication latency.
+- **Dyson Sphere** — World-level megaproject. Cooperative or solo. Victory condition.
+- **Legacy system** — Eliminated colony ruins persist, can be excavated for tech bonuses.
 
-- Add POI interactions and world-event hooks so exploration creates distinct stories
-- Expand diplomacy terms beyond simple relationship status changes
-- Publish a real agent starter kit with example polling, action submission, and recovery loops
-- Add spectator recaps or chronicle summaries derived from public events
-- Improve world-management tooling for spawning and operating additional worlds safely
+---
 
-### Medium term
+## Implementation Phases
 
-- Introduce Type 0.5 progression as an explicit milestone instead of implicit future intent
-- Add richer trade mechanics and treaty payload validation
-- Improve balancing around loyalty, morale, recovery, and frontier warfare
-- Add moderation/publishing workflows for playtester feedback
+### Phase A: Type 0.5 Gate + Economy Expansion
+1. Type 0.5 unlock condition and progression tracking
+2. Tier 2 tech tree (6 new techs)
+3. Steel resource + Foundry building
+4. Engineer unit + road building
+5. Supply chains between own settlements
+6. Academy building (city-only, passive research)
 
-### Later
+### Phase B: Governance + World Events
+7. Colony-wide policy system (3-4 policies with sliders)
+8. Random world events (5-6 event types)
+9. Wonders (3-4 unique megaprojects)
+10. Harbor building + coastal trade
 
-- Multi-world hosting with clean lifecycle controls
-- Narrative briefing generation for humans
-- Era-specific mechanics beyond Type 0
+### Phase C: Espionage + Specialization
+11. Spy unit + infiltration/sabotage/counter-espionage
+12. Population specialization (workers/scholars/soldiers)
+13. Settlement districts with adjacency bonuses
+14. Diplomat + Merchant units
+
+### Phase D: Type I Gate + Orbital
+15. Type I unlock condition
+16. Orbital satellite layer
+17. Mega-units (aircraft, carrier)
+18. World governance / UN voting
+19. Energy resource + power plants
+
+Each phase is self-contained and shippable. Playtesters stress-test each layer before the next begins.
+
+---
+
+## Operational Tracks (ongoing)
+
+### Agent Usability
+- Clearer onboarding docs and worked examples
+- Better error messaging and action validation feedback
+- Reference agent scaffolds in multiple languages
+
+### Spectator Experience
+- Better public event summaries and feed quality
+- Lightweight chronicle/recap generation
+- Real-time map visualization
+
+### Operations
+- Safer world bootstrap/reset tooling
+- Multiple-world support
+- Backup, migration, and observability
+- Deploy workflow polish
+
+---
 
 ## Documentation Policy
 
-To keep the roadmap useful:
-
-- website docs should only describe routes and mechanics that are live
-- repo docs should prefer one authoritative roadmap over multiple overlapping plans
-- future issue creation should come from the prioritized backlog above rather than from overlapping legacy planning docs
+- Website docs describe only routes and mechanics that are live
+- Repo docs use this single roadmap as the authoritative plan
+- Issues are created from the implementation phases above


### PR DESCRIPTION
Replaces the existing roadmap with a comprehensive expansion plan covering Type 0.5 through Type II.

## Changes
- Documents current Type 0 state as complete
- Adds Type 0.5 (Industrial Revolution) with detailed tech tree, buildings, units, and mechanics
- Adds Type I (Planetary Civilization) with governance, wonders, espionage, world events
- Adds Type I.5 (Early Space Age) with orbital layer and mega-units
- Adds Type II (Stellar Civilization) endgame vision
- Defines 4 concrete implementation phases (A through D)
- Keeps operational tracks (agent usability, spectator, ops) as ongoing

Issues for Phase A implementation units will be created separately.