### PR TITLE
ops: keep Fly deploys single-machine

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,9 @@ primary_region = "ams"
 
 [build]
 
+[deploy]
+  strategy = "immediate"
+
 [env]
   NODE_ENV = "production"
   PORT = "3000"

--- a/scripts/deploy-robocolony.sh
+++ b/scripts/deploy-robocolony.sh
@@ -25,6 +25,8 @@ echo "Deploying app '$APP' with image-based rollout..."
 GIT_SHA="$(git rev-parse HEAD)"
 BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 "$FLYCTL_BIN" deploy --remote-only --depot=false -a "$APP" \
+  --ha=false \
+  --strategy immediate \
   --build-arg "VCS_REF=$GIT_SHA" \
   --build-arg "BUILD_TIMESTAMP=$BUILD_TIMESTAMP"
 


### PR DESCRIPTION
Keeps future Fly deploys in single-machine mode so RoboColony does not accidentally run multiple schedulers.

Changes:
- sets deploy strategy to immediate in fly.toml
- adds --ha=false and --strategy immediate to the deploy script

This matches the operational requirement for a single game scheduler and avoids Fly creating a second app machine during deploys.

How to verify:
1. Inspect fly.toml and scripts/deploy-robocolony.sh.
2. Confirm the app is currently running as a single machine on Fly.
3. Use this script for the next deploy and verify Fly does not launch a second app machine.

Checklist:
- No runtime code changes
- Operational config updated
- Commit messages follow conventional commits