### PR TITLE
balance: resolve critically wounded units by end of tick

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -52,6 +52,7 @@ import {
   GRANARY_BONUS_PER_LEVEL,
   STOCKPILE_DECAY_RATE,
   HEALING_PER_TICK,
+  CRITICAL_WOUND_THRESHOLD,
   BARRACKS_HEALING_BONUS,
   SETTLEMENT_LOYALTY_RECOVERY,
   SETTLEMENT_GARRISON_LOYALTY_BONUS,
@@ -1453,6 +1454,50 @@ describe('resolveTick', () => {
     expect(healedUnit?.health).toBeLessThanOrEqual(25);
     expect(result.events.some(e => e.type === 'garrison_heal' && e.unitId === 'u1')).toBe(false);
     expect(result.events.some(e => e.type === 'combat_resolved')).toBe(true);
+  });
+
+  it('removes critically wounded military units stranded away from friendly settlements', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ hexX: 0, hexY: 0 });
+    const unit = makeUnit({
+      id: 'u1',
+      colonyId: colony.id,
+      type: 'soldier',
+      hexX: 2,
+      hexY: 0,
+      health: CRITICAL_WOUND_THRESHOLD,
+    });
+
+    const result = resolveTick([colony], [settlement], [unit], makePlainLine(3), []);
+
+    expect(result.units.find(u => u.id === 'u1')).toBeUndefined();
+    expect(result.events.some(
+      e => e.type === 'unit_destroyed'
+        && e.unitId === 'u1'
+        && `${e.data.reason}`.includes('friendly settlement'),
+    )).toBe(true);
+  });
+
+  it('lets critically wounded military units survive on a friendly settlement', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ id: 's1', colonyId: colony.id, hexX: 0, hexY: 0, buildings: [] });
+    const unit = makeUnit({
+      id: 'u1',
+      colonyId: colony.id,
+      type: 'soldier',
+      hexX: 0,
+      hexY: 0,
+      health: CRITICAL_WOUND_THRESHOLD,
+      morale: 0.7,
+    });
+
+    const result = resolveTick([colony], [settlement], [unit], makePlainLine(1), []);
+
+    expect(result.units.find(u => u.id === 'u1')).toMatchObject({
+      id: 'u1',
+      health: CRITICAL_WOUND_THRESHOLD + HEALING_PER_TICK,
+    });
+    expect(result.events.some(e => e.type === 'garrison_heal' && e.unitId === 'u1')).toBe(true);
   });
 
   it('returns immutable results (does not mutate inputs)', () => {

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -651,6 +651,8 @@ export const COMBAT_MINIMUM_DAMAGE = 1;
 
 /** Health threshold below which military units bleed out after combat (#174) */
 export const COMBAT_BLEEDOUT_THRESHOLD = 5;
+/** Health threshold below which military units require friendly shelter by end of tick */
+export const CRITICAL_WOUND_THRESHOLD = 6;
 export const NEWCOMER_PROTECTION_TICKS = 24;
 
 /** Base health recovered per tick at a friendly settlement */
@@ -3967,6 +3969,7 @@ export function resolveTick(
 ): TickResult {
   const events: TickEvent[] = [];
   const desertedUnitIds: string[] = [];
+  const criticalWoundUnitIds: string[] = [];
   let actionResults: ActionResult[] = [];
   let fogReveals: HexExploration[] = [];
   let newMessages: MessageRecord[] = [];
@@ -4917,6 +4920,34 @@ export function resolveTick(
       }
     }
 
+    // Critically wounded units need to reach a friendly settlement to survive.
+    for (const unit of myUnits) {
+      if (criticalWoundUnitIds.includes(unit.id)) continue;
+      if (!MILITARY_UNIT_TYPES.has(unit.type)) continue;
+      if (unit.health > CRITICAL_WOUND_THRESHOLD) continue;
+
+      const onFriendlySettlement = mySettlements.some(
+        settlement => settlement.hexX === unit.hexX && settlement.hexY === unit.hexY,
+      );
+      if (onFriendlySettlement) continue;
+
+      criticalWoundUnitIds.push(unit.id);
+      unit.health = 0;
+      events.push({
+        type: 'unit_destroyed',
+        colonyId: colony.id,
+        unitId: unit.id,
+        data: {
+          unitType: unit.type,
+          hexX: unit.hexX,
+          hexY: unit.hexY,
+          killedInCombat: false,
+          damageReceived: 0,
+          reason: `Critically wounded ${unit.type} perished without reaching a friendly settlement`,
+        },
+      });
+    }
+
     // --- Food deficit: famine triggers on meaningful negative net food production ---
     // Suppress famine warnings when:
     // 1. Deficit is tiny (< 1.0/tick) — likely rounding noise or pop growth oscillation
@@ -5124,7 +5155,8 @@ export function resolveTick(
   }
 
   // Remove deserted units
-  const survivingUnits = updatedUnits.filter(u => !desertedUnitIds.includes(u.id));
+  const removedUnitIds = new Set([...desertedUnitIds, ...criticalWoundUnitIds]);
+  const survivingUnits = updatedUnits.filter(u => !removedUnitIds.has(u.id));
 
   // Emit action_failed events so failures appear in the event feed
   for (const ar of actionResults) {


### PR DESCRIPTION
Closes #262\nCloses #266\n\n## What does this PR do?\n\nPrevents near-dead military units from lingering indefinitely after combat. Units at or below the critical threshold now perish by end of tick unless they are on a friendly settlement, where garrison healing can save them.\n\n## Verification\n\n- Tick combat tests pass\n- TypeScript check passes