### PR TITLE
fix: preserve coordinates on public unit destroyed events

### DIFF
--- a/src/engine/__tests__/scheduler.test.ts
+++ b/src/engine/__tests__/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { eventVisibility } from '../scheduler.js';
+import { buildPublicData, eventVisibility } from '../scheduler.js';
 
 describe('eventVisibility', () => {
   it('includes both agreement parties for private diplomacy events', () => {
@@ -12,5 +12,27 @@ describe('eventVisibility', () => {
     });
 
     expect(new Set(visibility)).toEqual(new Set(['colony-1', 'colony-2']));
+  });
+});
+
+describe('buildPublicData', () => {
+  it('keeps hex coordinates for public unit_destroyed events', () => {
+    const data = buildPublicData({
+      type: 'unit_destroyed',
+      colonyId: 'colony-1',
+      data: {
+        unitType: 'soldier',
+        hexX: 7,
+        hexY: -2,
+        cause: 'combat',
+      },
+    });
+
+    expect(data).toEqual({
+      unitType: 'soldier',
+      hexX: 7,
+      hexY: -2,
+      cause: 'combat',
+    });
   });
 });

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -44,7 +44,7 @@ const PUBLIC_EVENT_TYPES = new Set([
  * Build public-safe data for spectator feed.
  * Strips private info (exact resource amounts) but keeps the interesting bits.
  */
-function buildPublicData(event: { type: string; colonyId?: string; data: Record<string, unknown> }): Record<string, unknown> | null {
+export function buildPublicData(event: { type: string; colonyId?: string; data: Record<string, unknown> }): Record<string, unknown> | null {
   switch (event.type) {
     case 'settlement_founded':
       return {
@@ -94,6 +94,8 @@ function buildPublicData(event: { type: string; colonyId?: string; data: Record<
     case 'unit_destroyed':
       return {
         unitType: event.data.unitType,
+        hexX: event.data.hexX,
+        hexY: event.data.hexY,
         cause: event.data.cause || 'combat',
       };
     case 'research_complete':
@@ -814,6 +816,3 @@ export class TickScheduler {
     }
   }
 }
-
-
-


### PR DESCRIPTION
Closes #269\n\n## What does this PR do?\n\nKeeps hexX and hexY on public unit_destroyed events so enemy destruction reports remain actionable in the public feed.\n\n## Verification\n\n- Scheduler tests pass\n- TypeScript check passes