### PR TITLE
balance: scale action capacity with settlements

### DIFF
--- a/src/routes/__tests__/actions.test.ts
+++ b/src/routes/__tests__/actions.test.ts
@@ -154,30 +154,35 @@ describe('Action validation', () => {
 });
 
 describe('Rate limiting', () => {
-  const MAX_ACTIONS_PER_TICK = 10;
+  const getMaxActionsPerTick = (settlementCount: number) => 10 + settlementCount * 2;
 
   it('allows up to 10 actions per tick', () => {
     const currentQueued = 0;
     const newActions = 10;
-    expect(newActions <= MAX_ACTIONS_PER_TICK - currentQueued).toBe(true);
+    expect(newActions <= getMaxActionsPerTick(0) - currentQueued).toBe(true);
   });
 
   it('rejects when queue is full', () => {
-    const currentQueued = 10;
+    const currentQueued = getMaxActionsPerTick(0);
     const newActions = 1;
-    expect(newActions <= MAX_ACTIONS_PER_TICK - currentQueued).toBe(false);
+    expect(newActions <= getMaxActionsPerTick(0) - currentQueued).toBe(false);
   });
 
   it('allows partial fill', () => {
     const currentQueued = 7;
     const newActions = 3;
-    expect(newActions <= MAX_ACTIONS_PER_TICK - currentQueued).toBe(true);
+    expect(newActions <= getMaxActionsPerTick(0) - currentQueued).toBe(true);
   });
 
   it('rejects overfill', () => {
     const currentQueued = 7;
     const newActions = 4;
-    expect(newActions <= MAX_ACTIONS_PER_TICK - currentQueued).toBe(false);
+    expect(newActions <= getMaxActionsPerTick(0) - currentQueued).toBe(false);
+  });
+
+  it('scales action capacity with settlements', () => {
+    expect(getMaxActionsPerTick(1)).toBe(12);
+    expect(getMaxActionsPerTick(9)).toBe(28);
   });
 });
 

--- a/src/routes/__tests__/actionsRoute.test.ts
+++ b/src/routes/__tests__/actionsRoute.test.ts
@@ -12,10 +12,14 @@ vi.mock('../../middleware/index.js', () => ({
 }));
 
 const updateWhereMock = vi.fn().mockResolvedValue({ rowCount: 0 });
+const insertValuesMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../db/index.js', () => ({
   db: {
     select: vi.fn(),
+    insert: vi.fn(() => ({
+      values: insertValuesMock,
+    })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
         where: updateWhereMock,
@@ -56,6 +60,7 @@ describe('Action submission route', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     updateWhereMock.mockResolvedValue({ rowCount: 0 });
+    insertValuesMock.mockResolvedValue(undefined);
     app = Fastify({ logger: false });
     await app.register(actionRoutes);
   });
@@ -67,6 +72,7 @@ describe('Action submission route', () => {
   it('rejects research submissions when the colony has no workshop', async () => {
     mockDbSelectQueue([
       [{ currentTick: 42, status: 'active', mapRadius: 12 }],
+      [{ count: 1 }],
       [{ buildings: [{ type: 'farm', level: 1 }] }],
     ]);
 
@@ -93,5 +99,36 @@ describe('Action submission route', () => {
         },
       ],
     });
+  });
+
+  it('scales action capacity with settlement count', async () => {
+    mockDbSelectQueue([
+      [{ currentTick: 42, status: 'active', mapRadius: 12 }],
+      [{ count: 9 }],
+      [{ count: 0 }],
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/world-1/actions',
+      headers: {
+        authorization: 'Bearer rc_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      payload: {
+        actions: Array.from({ length: 24 }, (_, i) => ({
+          type: 'send_message',
+          params: {
+            toColonyId: `colony-${i + 2}`,
+            message: `Reinforce front ${i + 1}`,
+          },
+        })),
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = response.json();
+    expect(body.submitted).toBe(24);
+    expect(body.truncated).toBeUndefined();
+    expect(insertValuesMock).toHaveBeenCalledTimes(24);
   });
 });

--- a/src/routes/actions.ts
+++ b/src/routes/actions.ts
@@ -98,7 +98,8 @@ const VALID_AGREEMENT_TYPES = new Set([
   'non_aggression', 'trade', 'alliance', 'ceasefire',
 ]);
 
-const MAX_ACTIONS_PER_TICK = 10;
+const BASE_ACTIONS_PER_TICK = 10;
+const ACTIONS_PER_SETTLEMENT = 2;
 const MAX_SETTLEMENT_NAME_LENGTH = 40;
 const MAX_MESSAGE_LENGTH = 500;
 
@@ -153,6 +154,24 @@ function isFiniteNum(val: unknown): val is number {
 interface ValidationResult {
   valid: boolean;
   error?: string;
+}
+
+export function getMaxActionsPerTick(settlementCount: number): number {
+  return BASE_ACTIONS_PER_TICK + Math.max(0, settlementCount) * ACTIONS_PER_SETTLEMENT;
+}
+
+async function getQueuedActionLimit(colonyId: string, worldId: string): Promise<number> {
+  const settlementCountRows = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(settlements)
+    .where(
+      and(
+        eq(settlements.worldId, worldId),
+        eq(settlements.colonyId, colonyId),
+      ),
+    );
+
+  return getMaxActionsPerTick(Number(settlementCountRows[0]?.count ?? 0));
 }
 
 /**
@@ -467,7 +486,11 @@ export async function actionRoutes(app: FastifyInstance) {
   // Action schema — discover valid action types and their params (no auth required)
   app.get('/api/worlds/:id/actions/schema', async (_request, reply) => {
     return {
-      maxActionsPerTick: MAX_ACTIONS_PER_TICK,
+      maxActionsPerTick: BASE_ACTIONS_PER_TICK,
+      actionCapacity: {
+        basePerTick: BASE_ACTIONS_PER_TICK,
+        perSettlement: ACTIONS_PER_SETTLEMENT,
+      },
       actionTypes: getActionSchema(),
     };
   });
@@ -512,6 +535,7 @@ export async function actionRoutes(app: FastifyInstance) {
     const currentTick = world[0].currentTick;
     const nextTick = currentTick + 1;
     const mapRadius = world[0].mapRadius;
+    const maxActionsPerTick = await getQueuedActionLimit(colony.id, worldId);
 
     // Auto-expire stale queued actions from previous ticks
     await expireStaleActions(worldId, currentTick);
@@ -564,7 +588,7 @@ export async function actionRoutes(app: FastifyInstance) {
       );
 
     const currentQueuedCount = Number(existingCount[0]?.count ?? 0);
-    const remainingSlots = MAX_ACTIONS_PER_TICK - currentQueuedCount;
+    const remainingSlots = maxActionsPerTick - currentQueuedCount;
 
     // Truncate batch to fit remaining slots (partial accept)
     let truncated = false;
@@ -572,7 +596,7 @@ export async function actionRoutes(app: FastifyInstance) {
       if (remainingSlots <= 0) {
         return reply.code(429).send({
           error: 'rate_limit',
-          message: `Rate limit: max ${MAX_ACTIONS_PER_TICK} actions per tick. You have ${currentQueuedCount} queued, 0 remaining.`,
+          message: `Rate limit: max ${maxActionsPerTick} actions per tick. You have ${currentQueuedCount} queued, 0 remaining.`,
         });
       }
       body.actions = body.actions.slice(0, remainingSlots);
@@ -609,7 +633,7 @@ export async function actionRoutes(app: FastifyInstance) {
       actions: inserted,
       ...(truncated ? {
         truncated: true,
-        message: `Batch truncated: ${inserted.length} of your actions accepted (max ${MAX_ACTIONS_PER_TICK}/tick, ${currentQueuedCount} already queued).`,
+        message: `Batch truncated: ${inserted.length} of your actions accepted (max ${maxActionsPerTick}/tick, ${currentQueuedCount} already queued).`,
       } : {}),
     });
   });
@@ -634,6 +658,7 @@ export async function actionRoutes(app: FastifyInstance) {
 
     const currentTick = world[0].currentTick;
     const nextTick = currentTick + 1;
+    const maxActionsPerTick = await getQueuedActionLimit(colony.id, worldId);
 
     // Auto-expire stale queued actions from previous ticks
     await expireStaleActions(worldId, currentTick);
@@ -685,7 +710,7 @@ export async function actionRoutes(app: FastifyInstance) {
       tick: currentTick,
       queued: {
         count: queued.length,
-        maxPerTick: MAX_ACTIONS_PER_TICK,
+        maxPerTick: maxActionsPerTick,
         actions: queued,
       },
       recent: recent,


### PR DESCRIPTION
Closes #283\n\n## What does this PR do?\n\nScales per-tick action capacity with empire size using a base pool plus bonus actions per owned settlement. This keeps larger empires responsive without removing queue limits entirely.\n\n## Verification\n\n- Actions route tests pass\n- TypeScript check passes