### PR TITLE
fix: delete destroyed units from persisted state

### DIFF
--- a/src/engine/__tests__/scheduler.test.ts
+++ b/src/engine/__tests__/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildPublicData } from '../scheduler.js';
+import { buildPublicData, findRemovedUnitIds } from '../scheduler.js';
 
 describe('buildPublicData', () => {
   it('keeps hex coordinates for public unit_destroyed events', () => {
@@ -20,5 +20,24 @@ describe('buildPublicData', () => {
       hexY: -2,
       cause: 'combat',
     });
+  });
+});
+
+describe('findRemovedUnitIds', () => {
+  it('returns units that no longer exist in the final tick result', () => {
+    const removed = findRemovedUnitIds(
+      [
+        { id: 'unit-a' },
+        { id: 'unit-b' },
+        { id: 'unit-c' },
+      ],
+      [
+        { id: 'unit-a' },
+        { id: 'unit-c' },
+        { id: 'unit-d' },
+      ],
+    );
+
+    expect(removed).toEqual(['unit-b']);
   });
 });

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -148,6 +148,16 @@ export function eventVisibility(event: { colonyId?: string; data: Record<string,
   return [...visibility];
 }
 
+export function findRemovedUnitIds(
+  previousUnits: Array<{ id: string }>,
+  nextUnits: Array<{ id: string }>,
+): string[] {
+  const nextUnitIds = new Set(nextUnits.map(unit => unit.id));
+  return previousUnits
+    .map(unit => unit.id)
+    .filter(unitId => !nextUnitIds.has(unitId));
+}
+
 function eventDedupKey(event: { type: string; data: Record<string, unknown> }): string | null {
   switch (event.type) {
     case 'combat_resolved':
@@ -536,6 +546,16 @@ export class TickScheduler {
 
         // Delete disbanded units
         for (const unitId of result.disbandedUnitIds) {
+          await tx
+            .delete(schema.units)
+            .where(eq(schema.units.id, unitId));
+        }
+
+        // Delete units removed by combat or end-of-tick cleanup.
+        // The tick engine returns the authoritative surviving unit list, so any
+        // previously persisted unit missing from result.units must be removed.
+        const removedUnitIds = findRemovedUnitIds(dbUnits, result.units);
+        for (const unitId of removedUnitIds) {
           await tx
             .delete(schema.units)
             .where(eq(schema.units.id, unitId));


### PR DESCRIPTION
Closes #289\nCloses #290\n\n## What does this PR do?\n\nDeletes units from the database when they disappear from the authoritative tick result, instead of only upserting survivors. This fixes destroyed units reappearing in /state and the resulting zombie low-HP garrisons.\n\n## Verification\n\n- scheduler tests pass\n- tick/state regression tests pass\n- TypeScript check passes