### PR TITLE
feat: introduce first-class star systems foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the current product roadmap and scope
 ## Documentation
 
 - **[Roadmap](docs/roadmap.md)** — current product direction, shipped scope, and next priorities
+- **[Star Systems Foundation](docs/star-systems.md)** — how the current world model evolves into a system layer
 - **[Contributing](CONTRIBUTING.md)** — how to set up, code style, PR workflow
 
 ## Status

--- a/docs/star-systems.md
+++ b/docs/star-systems.md
@@ -1,0 +1,145 @@
+# Star Systems Foundation
+
+This document defines the first non-breaking step from RoboColony's current world-first model toward a true system layer.
+
+## Why Introduce Star Systems Now
+
+Today, a `world` is both:
+
+- the playable surface theater
+- the scheduler boundary
+- the main strategic unit
+
+That works for the current Type 0 game, but it breaks down once orbital infrastructure, fleets, or multiple inhabited worlds need to coexist in the same simulation. A star system needs to become the strategic container above one or more worlds.
+
+## Proposed Model
+
+### `star_systems`
+
+`star_systems` becomes the new strategic container. A system can own:
+
+- one or more surface worlds
+- orbital infrastructure
+- future route and fleet state
+- claims, strategic importance, and galaxy-map position
+
+The initial schema keeps this light:
+
+- `id`, `name`
+- `status`
+- `importance`
+- `position_x`, `position_y`
+- `claimants`
+- `neighbor_system_ids`
+- `metadata`
+
+This is enough to make systems first-class without yet forcing a full route graph or polity model.
+
+### `worlds`
+
+`worlds` remains the current playable surface theater, but it is no longer assumed to be the top simulation layer.
+
+New non-breaking world metadata:
+
+- `star_system_id`
+- `theater_type`
+- `orbital_slot`
+
+That lets an existing world be interpreted as:
+
+- a surface world inside a star system
+- a moon or habitat later on
+- a special-case isolated test world with no system assigned yet
+
+## Ownership, Claims, and Importance
+
+This first step deliberately keeps system-level ownership flexible.
+
+- `claimants` stores the current list of colonies, factions, or future polity IDs with standing in the system
+- `importance` is a lightweight strategic weight for scheduling, recap generation, and future AI prioritization
+- richer governance should come later through sector and polity work rather than overfitting the first schema
+
+## Connectivity
+
+`neighbor_system_ids` is a temporary placeholder for local topology.
+
+It is not the final galaxy graph format. The intended path is:
+
+1. first-class system identity
+2. galaxy graph and sector topology
+3. route costs, travel rules, and communication latency
+
+That sequencing keeps `#253` focused on system identity rather than solving all galaxy travel at once.
+
+## Scheduler Implications
+
+Current state:
+
+- one authoritative scheduler per world
+
+Near-term implication:
+
+- keep per-world schedulers for current gameplay
+- allow many worlds to belong to one star system
+- treat the system as metadata and future coordination context, not yet as the main tick owner
+
+Planned transition:
+
+1. worlds continue to tick independently while system metadata is attached
+2. orbital and route state is introduced at the system layer
+3. a system coordinator can eventually orchestrate multiple local theaters
+4. galaxy-level LOD decides whether the system runs in aggregate or in detailed mode
+
+This preserves determinism and avoids forcing a scheduler rewrite before the system model exists.
+
+## API Implications
+
+Short term:
+
+- existing world APIs continue to work unchanged
+- world responses can safely expose `starSystemId`, `theaterType`, and `orbitalSlot`
+
+Medium term:
+
+- add system endpoints for listing systems and inspecting a single system
+- expose which worlds belong to a system
+- expose future orbital assets, fleets, claims, and strategic summaries at the system layer
+
+The important rule is that surface APIs should remain valid even after systems exist. Agents that only understand the current world game should keep working.
+
+## Initial Implementation Plan
+
+### Step 1
+
+Add first-class `star_systems` schema and nullable links from `worlds`.
+
+### Step 2
+
+Backfill existing worlds as standalone surface theaters:
+
+- either no `star_system_id` yet
+- or one system per existing world for migration convenience
+
+### Step 3
+
+Expose system metadata in world reads without changing existing action semantics.
+
+### Step 4
+
+Introduce dedicated system endpoints and seed tools.
+
+### Step 5
+
+Move orbital infrastructure, fleets, and system logistics into the new layer.
+
+## What This Defers
+
+This issue should not try to solve:
+
+- full interstellar travel
+- sector governance
+- multi-system polities
+- final LOD strategy
+- Dyson-scale simulation
+
+Those remain follow-on work after systems are first-class and stable.

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -21,6 +21,18 @@ interface ColumnDef {
 }
 
 const CREATE_TABLE_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS star_systems (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'surveyed',
+    importance INTEGER NOT NULL DEFAULT 0,
+    position_x INTEGER,
+    position_y INTEGER,
+    claimants JSONB NOT NULL DEFAULT '[]'::jsonb,
+    neighbor_system_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )`,
   `CREATE TABLE IF NOT EXISTS feedback_reports (
     id TEXT PRIMARY KEY,
     world_id TEXT NOT NULL REFERENCES worlds(id),
@@ -52,7 +64,22 @@ const EXPECTED_COLUMNS: ColumnDef[] = [
   { table: 'worlds', column: 'status', type: 'TEXT', defaultValue: "'open'" },
   { table: 'worlds', column: 'map_radius', type: 'INTEGER', defaultValue: '50' },
   { table: 'worlds', column: 'max_colonies', type: 'INTEGER', defaultValue: '8' },
+  { table: 'worlds', column: 'star_system_id', type: 'TEXT', nullable: true },
+  { table: 'worlds', column: 'theater_type', type: 'TEXT', defaultValue: "'surface'" },
+  { table: 'worlds', column: 'orbital_slot', type: 'INTEGER', nullable: true },
   { table: 'worlds', column: 'created_at', type: 'TIMESTAMPTZ', defaultValue: 'NOW()', nullable: true },
+
+  // star_systems
+  { table: 'star_systems', column: 'id', type: 'TEXT' },
+  { table: 'star_systems', column: 'name', type: 'TEXT' },
+  { table: 'star_systems', column: 'status', type: 'TEXT', defaultValue: "'surveyed'" },
+  { table: 'star_systems', column: 'importance', type: 'INTEGER', defaultValue: '0' },
+  { table: 'star_systems', column: 'position_x', type: 'INTEGER', nullable: true },
+  { table: 'star_systems', column: 'position_y', type: 'INTEGER', nullable: true },
+  { table: 'star_systems', column: 'claimants', type: 'JSONB', defaultValue: "'[]'::jsonb" },
+  { table: 'star_systems', column: 'neighbor_system_ids', type: 'JSONB', defaultValue: "'[]'::jsonb" },
+  { table: 'star_systems', column: 'metadata', type: 'JSONB', defaultValue: "'{}'::jsonb" },
+  { table: 'star_systems', column: 'created_at', type: 'TIMESTAMPTZ', defaultValue: 'NOW()', nullable: true },
 
   // colonies
   { table: 'colonies', column: 'id', type: 'TEXT' },

--- a/src/db/schema/__tests__/schema.test.ts
+++ b/src/db/schema/__tests__/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getTableName, getTableColumns } from 'drizzle-orm';
 import { worlds } from '../worlds.js';
+import { starSystems } from '../starSystems.js';
 import { hexes } from '../hexes.js';
 import { colonies } from '../colonies.js';
 import { settlements } from '../settlements.js';
@@ -27,6 +28,29 @@ describe('Database schema', () => {
       expect(cols).toHaveProperty('status');
       expect(cols).toHaveProperty('mapRadius');
       expect(cols).toHaveProperty('maxColonies');
+      expect(cols).toHaveProperty('starSystemId');
+      expect(cols).toHaveProperty('theaterType');
+      expect(cols).toHaveProperty('orbitalSlot');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('star_systems table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(starSystems)).toBe('star_systems');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(starSystems);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('name');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('importance');
+      expect(cols).toHaveProperty('positionX');
+      expect(cols).toHaveProperty('positionY');
+      expect(cols).toHaveProperty('claimants');
+      expect(cols).toHaveProperty('neighborSystemIds');
+      expect(cols).toHaveProperty('metadata');
       expect(cols).toHaveProperty('createdAt');
     });
   });
@@ -200,9 +224,9 @@ describe('Database schema', () => {
     });
   });
 
-  it('all 10 tables are defined', () => {
-    const tables = [worlds, hexes, colonies, settlements, units, actions, agreements, messages, events, feedbackReports];
-    expect(tables).toHaveLength(10);
+  it('all 11 tables are defined', () => {
+    const tables = [worlds, starSystems, hexes, colonies, settlements, units, actions, agreements, messages, events, feedbackReports];
+    expect(tables).toHaveLength(11);
     tables.forEach(t => expect(getTableName(t)).toBeTruthy());
   });
 });

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 export { worlds } from './worlds.js';
+export { starSystems } from './starSystems.js';
 export { hexes } from './hexes.js';
 export { colonies } from './colonies.js';
 export { settlements } from './settlements.js';

--- a/src/db/schema/starSystems.ts
+++ b/src/db/schema/starSystems.ts
@@ -1,0 +1,14 @@
+import { pgTable, text, integer, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+export const starSystems = pgTable('star_systems', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  status: text('status').notNull().default('surveyed'),
+  importance: integer('importance').notNull().default(0),
+  positionX: integer('position_x'),
+  positionY: integer('position_y'),
+  claimants: jsonb('claimants').$type<string[]>().notNull().default([]),
+  neighborSystemIds: jsonb('neighbor_system_ids').$type<string[]>().notNull().default([]),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});

--- a/src/db/schema/worlds.ts
+++ b/src/db/schema/worlds.ts
@@ -9,5 +9,8 @@ export const worlds = pgTable('worlds', {
   status: text('status').notNull().default('open'), // open | running | full | ended
   mapRadius: integer('map_radius').notNull().default(50),
   maxColonies: integer('max_colonies').notNull().default(8),
+  starSystemId: text('star_system_id'),
+  theaterType: text('theater_type').notNull().default('surface'),
+  orbitalSlot: integer('orbital_slot'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });

--- a/src/routes/worlds.ts
+++ b/src/routes/worlds.ts
@@ -81,6 +81,9 @@ export async function worldRoutes(app: FastifyInstance) {
         status: worlds.status,
         currentTick: worlds.currentTick,
         maxColonies: worlds.maxColonies,
+        starSystemId: worlds.starSystemId,
+        theaterType: worlds.theaterType,
+        orbitalSlot: worlds.orbitalSlot,
         createdAt: worlds.createdAt,
       })
       .from(worlds);


### PR DESCRIPTION
## What does this PR do?

Introduces the first non-breaking system-layer foundation for RoboColony.

Changes include:
- add a first-class `star_systems` schema
- add nullable `starSystemId`, `theaterType`, and `orbitalSlot` metadata to `worlds`
- extend startup migration support for the new table and columns
- expose world system metadata on existing world reads without changing action semantics
- add `docs/star-systems.md` describing the data model, scheduler implications, API implications, and rollout plan

This keeps current planetary gameplay intact while establishing the architectural bridge into the future system layer.

## Related issue

Closes #253

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
3. Review `docs/star-systems.md` and the new schema fields in `src/db/schema/worlds.ts` and `src/db/schema/starSystems.ts`

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] No `any` types introduced
- [x] Commit messages follow conventional commits