### PR TITLE
feat: define hierarchical actors and delegations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the current product roadmap and scope
 - **[Galaxy Graph](docs/galaxy-graph.md)** — sectors, star-lane topology, and macro travel rules
 - **[Orbital Control](docs/orbital-control.md)** — fleets, orbital assets, and system-level conflict primitives
 - **[Simulation LOD](docs/simulation-lod.md)** — how quiet sectors compress while contested theaters stay detailed
+- **[Hierarchical Actors](docs/hierarchical-actors.md)** — colony, system, sector, and polity authority boundaries
 - **[Contributing](CONTRIBUTING.md)** — how to set up, code style, PR workflow
 
 ## Status

--- a/docs/hierarchical-actors.md
+++ b/docs/hierarchical-actors.md
@@ -1,0 +1,217 @@
+# Hierarchical Actors and Control Surfaces
+
+This document defines who acts at each simulation layer in RoboColony and what API/control surfaces they should eventually use.
+
+## Why This Layer Is Needed
+
+A galaxy with many worlds and systems cannot be modeled as one flat population of identical actors.
+
+Different decisions belong at different layers:
+
+- a local colony should not micromanage a whole sector
+- a sector authority should not issue per-unit surface moves directly
+- a future polity should reason about high-level priorities, not individual farms
+
+The simulation therefore needs a hierarchy of actors with explicit delegation boundaries.
+
+## Actor Layers
+
+### Colony Actor
+
+The colony actor is today's primary playable role.
+
+Responsibilities:
+
+- surface settlement growth
+- unit actions on the local theater
+- local diplomacy and messaging
+- immediate economic priorities
+
+Control surface today:
+
+- `GET /api/worlds/:id/state`
+- `POST /api/worlds/:id/actions`
+- world-scoped diplomacy and messaging endpoints
+
+### System Actor
+
+The system actor coordinates one star system and its worlds, fleets, and orbital assets.
+
+Responsibilities:
+
+- fleet posture inside the system
+- orbital asset priorities
+- inter-world logistics within the system
+- system-level threat response
+
+Future control surface:
+
+- `GET /api/systems/:id`
+- `GET /api/systems/:id/fleets`
+- `GET /api/systems/:id/orbital-assets`
+- future system-level action endpoints
+
+### Sector Actor
+
+The sector actor coordinates many systems in one region.
+
+Responsibilities:
+
+- reinforcement priorities across systems
+- strategic route weighting
+- LOD promotion/demotion decisions
+- regional stability and governance
+
+Future control surface:
+
+- `GET /api/sectors/:id`
+- future sector-level planning and posture endpoints
+
+### Polity Actor
+
+The polity actor represents a multi-sector state, federation, empire, or civilizational bloc.
+
+Responsibilities:
+
+- grand strategy
+- diplomatic doctrine
+- macroeconomic priorities
+- expansion versus consolidation decisions
+
+Future control surface:
+
+- future polity-level summaries and strategic commands
+
+## Authority Model
+
+Each actor should have an explicit authority scope rather than implied total control.
+
+Examples of authority scope:
+
+- `surface_actions`
+- `system_logistics`
+- `fleet_posture`
+- `route_control`
+- `sector_planning`
+- `grand_strategy`
+
+That makes delegation auditable and allows the game to preserve compatibility with simpler agents.
+
+## Delegation Model
+
+Delegation is how higher-level actors hand responsibility to lower-level actors without collapsing the hierarchy.
+
+Examples:
+
+- a polity actor delegates local growth to colony actors
+- a sector actor delegates interception execution to a system actor
+- a system actor delegates surface defense preparation to a colony actor
+
+Important rule:
+
+- delegation changes who may act on a control surface
+- delegation does not imply equal visibility or total authority
+
+## Visibility Rules
+
+Information should also be layered.
+
+### Colony Visibility
+
+- local world state
+- nearby diplomatic context
+- whatever system-level intelligence has been delegated or discovered
+
+### System Visibility
+
+- world membership
+- orbital asset state
+- fleet state
+- lane pressure within or adjacent to the system
+
+### Sector Visibility
+
+- public and delegated summaries of constituent systems
+- aggregate logistics and pressure metrics
+- route and chokepoint importance
+
+### Polity Visibility
+
+- aggregate strategic summaries
+- diplomatic and expansion posture
+- macro resource and force trends
+
+The hierarchy only works if actors do not all receive the same raw data by default.
+
+## Compatibility With Today's API
+
+RoboColony should preserve the current single-colony API while expanding upward.
+
+That means:
+
+- colony actors remain first-class
+- higher-level actors are added, not substituted in abruptly
+- world-scoped actions remain valid for current agents
+- future actor-aware APIs should be additive rather than breaking
+
+## Data Model
+
+### Governance Actors
+
+`governance_actors` represents the actor hierarchy directly.
+
+Key fields:
+
+- `type`
+- `name`
+- `parent_actor_id`
+- `colony_id`
+- `star_system_id`
+- `sector_id`
+- `polity_id`
+- `authority_scope`
+- `visibility_scope`
+- `metadata`
+
+### Actor Delegations
+
+`actor_delegations` records which actor may act on whose behalf, over what scope, and through what control surface.
+
+Key fields:
+
+- `from_actor_id`
+- `to_actor_id`
+- `status`
+- `authority_scope`
+- `control_surface`
+- `visibility_rules`
+- `metadata`
+
+## API Evolution Plan
+
+### Step 1
+
+Keep the colony API intact and introduce actor metadata only in the data model.
+
+### Step 2
+
+Add read-only actor-aware summaries for systems and sectors.
+
+### Step 3
+
+Add delegation-aware control surfaces for fleets, orbital assets, and sector planning.
+
+### Step 4
+
+Let strategic actors issue intent while local actors retain tactical execution authority.
+
+## What This Defers
+
+This issue should not try to implement:
+
+- a full permissions engine
+- authentication for every future actor type
+- complete multi-agent command routing
+- polity gameplay rules
+
+It only needs to make the hierarchy and delegation model explicit enough for later API and scheduler work.

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -97,6 +97,31 @@ const CREATE_TABLE_STATEMENTS = [
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
     created_at TIMESTAMPTZ DEFAULT NOW()
   )`,
+  `CREATE TABLE IF NOT EXISTS governance_actors (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    parent_actor_id TEXT,
+    colony_id TEXT,
+    star_system_id TEXT,
+    sector_id TEXT,
+    polity_id TEXT,
+    authority_scope JSONB NOT NULL DEFAULT '[]'::jsonb,
+    visibility_scope JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )`,
+  `CREATE TABLE IF NOT EXISTS actor_delegations (
+    id TEXT PRIMARY KEY,
+    from_actor_id TEXT NOT NULL,
+    to_actor_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    authority_scope JSONB NOT NULL DEFAULT '[]'::jsonb,
+    control_surface TEXT NOT NULL,
+    visibility_rules JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )`,
   `CREATE TABLE IF NOT EXISTS feedback_reports (
     id TEXT PRIMARY KEY,
     world_id TEXT NOT NULL REFERENCES worlds(id),
@@ -208,6 +233,31 @@ const EXPECTED_COLUMNS: ColumnDef[] = [
   { table: 'orbital_assets', column: 'visibility', type: 'TEXT', defaultValue: "'public'" },
   { table: 'orbital_assets', column: 'metadata', type: 'JSONB', defaultValue: "'{}'::jsonb" },
   { table: 'orbital_assets', column: 'created_at', type: 'TIMESTAMPTZ', defaultValue: 'NOW()', nullable: true },
+
+  // governance_actors
+  { table: 'governance_actors', column: 'id', type: 'TEXT' },
+  { table: 'governance_actors', column: 'type', type: 'TEXT' },
+  { table: 'governance_actors', column: 'name', type: 'TEXT' },
+  { table: 'governance_actors', column: 'parent_actor_id', type: 'TEXT', nullable: true },
+  { table: 'governance_actors', column: 'colony_id', type: 'TEXT', nullable: true },
+  { table: 'governance_actors', column: 'star_system_id', type: 'TEXT', nullable: true },
+  { table: 'governance_actors', column: 'sector_id', type: 'TEXT', nullable: true },
+  { table: 'governance_actors', column: 'polity_id', type: 'TEXT', nullable: true },
+  { table: 'governance_actors', column: 'authority_scope', type: 'JSONB', defaultValue: "'[]'::jsonb" },
+  { table: 'governance_actors', column: 'visibility_scope', type: 'JSONB', defaultValue: "'[]'::jsonb" },
+  { table: 'governance_actors', column: 'metadata', type: 'JSONB', defaultValue: "'{}'::jsonb" },
+  { table: 'governance_actors', column: 'created_at', type: 'TIMESTAMPTZ', defaultValue: 'NOW()', nullable: true },
+
+  // actor_delegations
+  { table: 'actor_delegations', column: 'id', type: 'TEXT' },
+  { table: 'actor_delegations', column: 'from_actor_id', type: 'TEXT' },
+  { table: 'actor_delegations', column: 'to_actor_id', type: 'TEXT' },
+  { table: 'actor_delegations', column: 'status', type: 'TEXT', defaultValue: "'active'" },
+  { table: 'actor_delegations', column: 'authority_scope', type: 'JSONB', defaultValue: "'[]'::jsonb" },
+  { table: 'actor_delegations', column: 'control_surface', type: 'TEXT' },
+  { table: 'actor_delegations', column: 'visibility_rules', type: 'JSONB', defaultValue: "'{}'::jsonb" },
+  { table: 'actor_delegations', column: 'metadata', type: 'JSONB', defaultValue: "'{}'::jsonb" },
+  { table: 'actor_delegations', column: 'created_at', type: 'TIMESTAMPTZ', defaultValue: 'NOW()', nullable: true },
 
   // colonies
   { table: 'colonies', column: 'id', type: 'TEXT' },

--- a/src/db/schema/__tests__/schema.test.ts
+++ b/src/db/schema/__tests__/schema.test.ts
@@ -6,6 +6,8 @@ import { sectors } from '../sectors.js';
 import { starLanes } from '../starLanes.js';
 import { fleets } from '../fleets.js';
 import { orbitalAssets } from '../orbitalAssets.js';
+import { governanceActors } from '../governanceActors.js';
+import { actorDelegations } from '../actorDelegations.js';
 import { hexes } from '../hexes.js';
 import { colonies } from '../colonies.js';
 import { settlements } from '../settlements.js';
@@ -150,6 +152,47 @@ describe('Database schema', () => {
       expect(cols).toHaveProperty('controlLevel');
       expect(cols).toHaveProperty('capacity');
       expect(cols).toHaveProperty('visibility');
+      expect(cols).toHaveProperty('metadata');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('governance_actors table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(governanceActors)).toBe('governance_actors');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(governanceActors);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('type');
+      expect(cols).toHaveProperty('name');
+      expect(cols).toHaveProperty('parentActorId');
+      expect(cols).toHaveProperty('colonyId');
+      expect(cols).toHaveProperty('starSystemId');
+      expect(cols).toHaveProperty('sectorId');
+      expect(cols).toHaveProperty('polityId');
+      expect(cols).toHaveProperty('authorityScope');
+      expect(cols).toHaveProperty('visibilityScope');
+      expect(cols).toHaveProperty('metadata');
+      expect(cols).toHaveProperty('createdAt');
+    });
+  });
+
+  describe('actor_delegations table', () => {
+    it('has correct table name', () => {
+      expect(getTableName(actorDelegations)).toBe('actor_delegations');
+    });
+
+    it('has all required columns', () => {
+      const cols = getTableColumns(actorDelegations);
+      expect(cols).toHaveProperty('id');
+      expect(cols).toHaveProperty('fromActorId');
+      expect(cols).toHaveProperty('toActorId');
+      expect(cols).toHaveProperty('status');
+      expect(cols).toHaveProperty('authorityScope');
+      expect(cols).toHaveProperty('controlSurface');
+      expect(cols).toHaveProperty('visibilityRules');
       expect(cols).toHaveProperty('metadata');
       expect(cols).toHaveProperty('createdAt');
     });
@@ -324,9 +367,9 @@ describe('Database schema', () => {
     });
   });
 
-  it('all 15 tables are defined', () => {
-    const tables = [worlds, starSystems, sectors, starLanes, fleets, orbitalAssets, hexes, colonies, settlements, units, actions, agreements, messages, events, feedbackReports];
-    expect(tables).toHaveLength(15);
+  it('all 17 tables are defined', () => {
+    const tables = [worlds, starSystems, sectors, starLanes, fleets, orbitalAssets, governanceActors, actorDelegations, hexes, colonies, settlements, units, actions, agreements, messages, events, feedbackReports];
+    expect(tables).toHaveLength(17);
     tables.forEach(t => expect(getTableName(t)).toBeTruthy());
   });
 });

--- a/src/db/schema/actorDelegations.ts
+++ b/src/db/schema/actorDelegations.ts
@@ -1,0 +1,13 @@
+import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+export const actorDelegations = pgTable('actor_delegations', {
+  id: text('id').primaryKey(),
+  fromActorId: text('from_actor_id').notNull(),
+  toActorId: text('to_actor_id').notNull(),
+  status: text('status').notNull().default('active'),
+  authorityScope: jsonb('authority_scope').$type<string[]>().notNull().default([]),
+  controlSurface: text('control_surface').notNull(),
+  visibilityRules: jsonb('visibility_rules').$type<Record<string, unknown>>().notNull().default({}),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});

--- a/src/db/schema/governanceActors.ts
+++ b/src/db/schema/governanceActors.ts
@@ -1,0 +1,16 @@
+import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+export const governanceActors = pgTable('governance_actors', {
+  id: text('id').primaryKey(),
+  type: text('type').notNull(),
+  name: text('name').notNull(),
+  parentActorId: text('parent_actor_id'),
+  colonyId: text('colony_id'),
+  starSystemId: text('star_system_id'),
+  sectorId: text('sector_id'),
+  polityId: text('polity_id'),
+  authorityScope: jsonb('authority_scope').$type<string[]>().notNull().default([]),
+  visibilityScope: jsonb('visibility_scope').$type<string[]>().notNull().default([]),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -4,6 +4,8 @@ export { sectors } from './sectors.js';
 export { starLanes } from './starLanes.js';
 export { fleets } from './fleets.js';
 export { orbitalAssets } from './orbitalAssets.js';
+export { governanceActors } from './governanceActors.js';
+export { actorDelegations } from './actorDelegations.js';
 export { hexes } from './hexes.js';
 export { colonies } from './colonies.js';
 export { settlements } from './settlements.js';


### PR DESCRIPTION
## What does this PR do?

Introduces the first explicit actor hierarchy above the current colony-only model.

Changes include:
- add first-class `governance_actors` schema
- add first-class `actor_delegations` schema
- extend startup migration support for the new tables
- add `docs/hierarchical-actors.md` describing colony, system, sector, and polity actors plus authority, delegation, visibility, and future API evolution
- link the new design doc from the README

This keeps the current single-colony API intact while making multi-layer authority and control-surface design explicit in the data model.

## Related issue

Closes #255

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
3. Review `docs/hierarchical-actors.md` plus the new schema files in `src/db/schema/`

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] No `any` types introduced
- [x] Commit messages follow conventional commits