### PR TITLE
feat: curate public feed events

### DIFF
--- a/src/routes/__tests__/feed.test.ts
+++ b/src/routes/__tests__/feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSpectatorRecap, type SpectatorFeedEvent } from '../feed.js';
+import { aggregateFeedEvents, buildSpectatorRecap, type SpectatorFeedEvent } from '../feed.js';
 
 describe('buildSpectatorRecap', () => {
   it('summarizes a mixed public event window into a recap', () => {
@@ -62,5 +62,100 @@ describe('buildSpectatorRecap', () => {
     expect(recap.endTick).toBeNull();
     expect(recap.eventCount).toBe(0);
     expect(recap.summary).toContain('Quiet frontier');
+  });
+});
+
+describe('aggregateFeedEvents', () => {
+  it('collapses repeated training events in the same tick and colony', () => {
+    const events: SpectatorFeedEvent[] = [
+      {
+        id: 'evt-1',
+        tick: 90,
+        type: 'unit_trained',
+        colonyId: 'col_a',
+        data: { unitType: 'soldier' },
+      },
+      {
+        id: 'evt-2',
+        tick: 90,
+        type: 'unit_trained',
+        colonyId: 'col_a',
+        data: { unitType: 'soldier' },
+      },
+      {
+        id: 'evt-3',
+        tick: 90,
+        type: 'unit_trained',
+        colonyId: 'col_a',
+        data: { unitType: 'militia' },
+      },
+    ];
+
+    const aggregated = aggregateFeedEvents(events);
+
+    expect(aggregated).toHaveLength(2);
+    expect(aggregated[0].groupedCount).toBe(2);
+    expect(aggregated[0].summary).toContain('trained 2 soldiers');
+    expect(aggregated[1].summary).toContain('trained 1 militia');
+  });
+
+  it('collapses zero-casualty combat spam on the same frontier location', () => {
+    const events: SpectatorFeedEvent[] = [
+      {
+        id: 'evt-1',
+        tick: 91,
+        type: 'combat_resolved',
+        colonyId: 'col_a',
+        data: { hexX: 4, hexY: -2, attackerLosses: 0, defenderLosses: 0 },
+      },
+      {
+        id: 'evt-2',
+        tick: 91,
+        type: 'combat_resolved',
+        colonyId: 'col_a',
+        data: { hexX: 4, hexY: -2, attackerLosses: 0, defenderLosses: 0 },
+      },
+      {
+        id: 'evt-3',
+        tick: 91,
+        type: 'combat_resolved',
+        colonyId: 'col_a',
+        data: { hexX: 6, hexY: -2, attackerLosses: 1, defenderLosses: 0 },
+      },
+    ];
+
+    const aggregated = aggregateFeedEvents(events);
+
+    expect(aggregated).toHaveLength(2);
+    expect(aggregated[0].importance).toBe('high');
+    expect(aggregated[1].groupedCount).toBe(2);
+    expect(aggregated[1].summary).toContain('2 clashes, no losses');
+  });
+
+  it('rolls lower-signal same-tick colony activity into a single summary row', () => {
+    const events: SpectatorFeedEvent[] = [
+      {
+        id: 'evt-1',
+        tick: 92,
+        type: 'build_complete',
+        colonyId: 'col_a',
+        data: { buildingType: 'farm', level: 1 },
+      },
+      {
+        id: 'evt-2',
+        tick: 92,
+        type: 'build_started',
+        colonyId: 'col_a',
+        data: { buildingType: 'lumber_mill', ticksRemaining: 3 },
+      },
+    ];
+
+    const aggregated = aggregateFeedEvents(events);
+
+    expect(aggregated).toHaveLength(1);
+    expect(aggregated[0].type).toBe('tick_summary');
+    expect(aggregated[0].groupedCount).toBe(2);
+    expect(aggregated[0].summary).toContain('activity update');
+    expect(aggregated[0].groupedTypes).toEqual(expect.arrayContaining(['build_complete', 'build_started']));
   });
 });

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -29,6 +29,10 @@ export interface SpectatorFeedEvent {
   colonyId: string | null;
   data: Record<string, unknown>;
   createdAt?: string;
+  summary?: string;
+  importance?: 'high' | 'normal' | 'low';
+  groupedCount?: number;
+  groupedTypes?: string[];
 }
 
 export interface SpectatorRecap {
@@ -44,6 +48,173 @@ const MAX_LIMIT = 200;
 
 function pluralize(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function getEventImportance(event: SpectatorFeedEvent): 'high' | 'normal' | 'low' {
+  switch (event.type) {
+    case 'settlement_founded':
+    case 'settlement_upgraded':
+    case 'settlement_captured':
+    case 'settlement_lost':
+    case 'research_complete':
+    case 'agreement_accepted':
+    case 'agreement_broken':
+    case 'colony_eliminated':
+      return 'high';
+    case 'unit_trained':
+    case 'build_complete':
+    case 'build_started':
+      return 'low';
+    case 'combat_resolved': {
+      const attackerLosses = Number(event.data.attackerLosses ?? 0);
+      const defenderLosses = Number(event.data.defenderLosses ?? 0);
+      return attackerLosses + defenderLosses > 0 ? 'high' : 'low';
+    }
+    default:
+      return 'normal';
+  }
+}
+
+function describeFeedEvent(event: SpectatorFeedEvent): string {
+  const data = event.data ?? {};
+  switch (event.type) {
+    case 'settlement_founded':
+      return typeof data.name === 'string' ? `founded ${data.name}` : 'founded a settlement';
+    case 'settlement_upgraded':
+      return typeof data.name === 'string'
+        ? `upgraded ${data.name} to ${String(data.tier ?? 'a higher tier')}`
+        : 'upgraded a settlement';
+    case 'research_complete':
+      return typeof data.techName === 'string' ? `completed ${data.techName} research` : 'completed research';
+    case 'unit_trained':
+      return typeof data.unitType === 'string' ? `trained ${data.unitType}` : 'trained a unit';
+    case 'build_complete':
+      return typeof data.buildingType === 'string' ? `completed ${data.buildingType}` : 'completed construction';
+    case 'combat_resolved': {
+      const attackerLosses = Number(data.attackerLosses ?? 0);
+      const defenderLosses = Number(data.defenderLosses ?? 0);
+      if (attackerLosses + defenderLosses === 0) {
+        return 'frontier skirmish with no losses';
+      }
+      return `combat with ${attackerLosses + defenderLosses} total losses`;
+    }
+    default:
+      return event.type.replace(/_/g, ' ');
+  }
+}
+
+function getCombatLocationKey(event: SpectatorFeedEvent): string {
+  const x = Number(event.data.hexX ?? NaN);
+  const y = Number(event.data.hexY ?? NaN);
+  return Number.isFinite(x) && Number.isFinite(y) ? `${x},${y}` : 'unknown';
+}
+
+export function aggregateFeedEvents(events: SpectatorFeedEvent[]): SpectatorFeedEvent[] {
+  const aggregated: SpectatorFeedEvent[] = [];
+
+  for (const event of events) {
+    const enriched: SpectatorFeedEvent = {
+      ...event,
+      importance: getEventImportance(event),
+    };
+
+    if (event.type === 'unit_trained') {
+      const unitType = typeof event.data.unitType === 'string' ? event.data.unitType : 'unit';
+      const existing = aggregated.find((candidate) =>
+        candidate.type === 'unit_trained'
+        && candidate.tick === event.tick
+        && candidate.colonyId === event.colonyId
+        && candidate.data.unitType === unitType,
+      );
+
+      if (existing) {
+        existing.groupedCount = (existing.groupedCount ?? 1) + 1;
+        existing.summary = `raised forces: trained ${existing.groupedCount} ${unitType}${existing.groupedCount === 1 ? '' : 's'}`;
+        continue;
+      }
+
+      enriched.groupedCount = 1;
+      enriched.summary = `raised forces: trained 1 ${unitType}`;
+      aggregated.push(enriched);
+      continue;
+    }
+
+    if (event.type === 'combat_resolved') {
+      const attackerLosses = Number(event.data.attackerLosses ?? 0);
+      const defenderLosses = Number(event.data.defenderLosses ?? 0);
+
+      if (attackerLosses + defenderLosses === 0) {
+        const locationKey = getCombatLocationKey(event);
+        const existing = aggregated.find((candidate) =>
+          candidate.type === 'combat_resolved'
+          && candidate.tick === event.tick
+          && candidate.colonyId === event.colonyId
+          && candidate.data.attackerLosses === 0
+          && candidate.data.defenderLosses === 0
+          && getCombatLocationKey(candidate) === locationKey,
+        );
+
+        if (existing) {
+          existing.groupedCount = (existing.groupedCount ?? 1) + 1;
+          existing.summary = `frontier skirmishing continued (${existing.groupedCount} clashes, no losses)`;
+          continue;
+        }
+
+        enriched.groupedCount = 1;
+        enriched.summary = 'frontier skirmish with no losses';
+        aggregated.push(enriched);
+        continue;
+      }
+    }
+
+    const existingTickSummary = aggregated.find((candidate) =>
+      candidate.type === 'tick_summary'
+      && candidate.tick === event.tick
+      && candidate.colonyId === event.colonyId
+      && candidate.importance === 'low'
+      && enriched.importance === 'low',
+    );
+
+    if (existingTickSummary) {
+      const existingSummaries = Array.isArray(existingTickSummary.data.summaries)
+        ? (existingTickSummary.data.summaries as string[])
+        : [];
+      const nextSummaries = [...existingSummaries, describeFeedEvent(enriched)];
+      existingTickSummary.data.summaries = nextSummaries;
+      existingTickSummary.data.groupedEvents = [...((existingTickSummary.data.groupedEvents as string[]) ?? []), enriched.type];
+      existingTickSummary.groupedCount = (existingTickSummary.groupedCount ?? 1) + 1;
+      existingTickSummary.groupedTypes = [...new Set((existingTickSummary.groupedTypes ?? []).concat(enriched.type))];
+      existingTickSummary.summary = `activity update: ${nextSummaries.slice(0, 3).join(', ')}${nextSummaries.length > 3 ? `, +${nextSummaries.length - 3} more` : ''}`;
+      continue;
+    }
+
+    if (enriched.importance === 'low' && event.type !== 'unit_trained' && event.type !== 'combat_resolved') {
+      aggregated.push({
+        ...enriched,
+        type: 'tick_summary',
+        id: `${event.id}:summary`,
+        groupedCount: 1,
+        groupedTypes: [event.type],
+        summary: `activity update: ${describeFeedEvent(enriched)}`,
+        data: {
+          summaries: [describeFeedEvent(enriched)],
+          groupedEvents: [event.type],
+        },
+      });
+      continue;
+    }
+
+    aggregated.push({
+      ...enriched,
+      summary: enriched.summary ?? describeFeedEvent(enriched),
+    });
+  }
+
+  return aggregated.sort((a, b) => {
+    if (b.tick !== a.tick) return b.tick - a.tick;
+    const priority = { high: 0, normal: 1, low: 2 } as const;
+    return priority[a.importance ?? 'normal'] - priority[b.importance ?? 'normal'];
+  });
 }
 
 export function buildSpectatorRecap(
@@ -204,14 +375,14 @@ export async function feedRoutes(app: FastifyInstance) {
       .limit(limit);
 
     // Map events: always prefer publicData for spectator view; never fall back to full data
-    const feedEvents = eventRows.map((row) => ({
+    const feedEvents = aggregateFeedEvents(eventRows.map((row) => ({
       id: row.id,
       tick: row.tick,
       type: row.type,
       colonyId: (row.visibility as string[] | null)?.[0] ?? null,
-      data: row.publicData ?? {},
+      data: (row.publicData ?? {}) as Record<string, unknown>,
       ...(row.createdAt ? { createdAt: row.createdAt.toISOString() } : {}),
-    }));
+    })));
 
     // Get colony summaries (public info only)
     const colonyRows = await db

--- a/web/index.html
+++ b/web/index.html
@@ -836,10 +836,10 @@
     // --- Filter logic ---
     const FILTER_MAP = {
       all: () => true,
-      production: (e) => e.type === 'production' || e.type === 'famine' || e.type === 'shortage' || e.type === '_repeated',
-      movement: (e) => e.type.includes('movement') || e.type === 'unit_moved' || e.type === '_repeated',
-      build: (e) => e.type.includes('build') || e.type === 'settlement_founded' || e.type === '_repeated',
-      military: (e) => ['combat_resolved', 'unit_destroyed', 'desertion', 'unit_trained', '_repeated'].includes(e.type),
+      production: (e) => e.type === 'production' || e.type === 'famine' || e.type === 'shortage' || (e.groupedTypes || []).some((type) => ['production', 'famine', 'shortage'].includes(type)) || e.type === '_repeated',
+      movement: (e) => e.type.includes('movement') || e.type === 'unit_moved' || (e.groupedTypes || []).some((type) => type.includes('movement') || type === 'unit_moved') || e.type === '_repeated',
+      build: (e) => e.type.includes('build') || e.type === 'settlement_founded' || (e.groupedTypes || []).some((type) => type.includes('build') || type === 'settlement_founded') || e.type === '_repeated',
+      military: (e) => ['combat_resolved', 'unit_destroyed', 'desertion', 'unit_trained', '_repeated'].includes(e.type) || (e.groupedTypes || []).some((type) => ['combat_resolved', 'unit_destroyed', 'desertion', 'unit_trained'].includes(type)),
     };
 
     document.querySelectorAll('.feed-controls button').forEach((btn) => {
@@ -873,6 +873,14 @@
 
     function formatEvent(event) {
       const d = event.data || {};
+      if (event.summary) {
+        const tone = event.importance === 'high'
+          ? '⭐ '
+          : event.importance === 'low'
+            ? '· '
+            : '';
+        return `${tone}${escapeHtml(event.summary)}`;
+      }
       switch (event.type) {
         case 'production': {
           const net = d.net || {};
@@ -945,11 +953,15 @@
           ? `<span class="event-colony">${escapeHtml(colony)}</span> `
           : '';
         const timeStr = event.createdAt ? formatEventTime(event.createdAt) : '';
+        const detailTag = event.groupedCount && event.groupedCount > 1
+          ? `<span class="event-time">${event.groupedCount} events</span>`
+          : '';
         return `
-          <li class="event-item ${event.type}">
+          <li class="event-item ${event.type} ${event.importance || 'normal'}">
             <div class="event-tick">
               <span>Tick ${event.tick}</span>
               ${timeStr ? `<span class="event-time">${timeStr}</span>` : ''}
+              ${detailTag}
             </div>
             <div class="event-text">${colonyTag}${formatEvent(event)}</div>
           </li>`;


### PR DESCRIPTION
Improves the spectator feed by collapsing repetitive low-signal rows into clearer summaries. This groups repeated unit training, summarizes repeated zero-casualty skirmishes, and rolls lower-signal same-tick colony activity into compact updates. It also updates the homepage renderer to show the new summaries and grouped event counts.