### PR TITLE
feat: add tier 2 research gating

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -11,6 +11,7 @@ import {
   resolveDemolish,
   resolvePoiSurvey,
   resolveCombat,
+  resolveResearch,
   buildingUpgradeCost,
   calculateProduction,
   calculateBuildingUpkeep,
@@ -64,6 +65,7 @@ import {
   IDLE_WARNING_TICKS,
   DEMOLISH_REFUND_RATE,
   DECAY_CHANCE_PER_BUILDING,
+  TECH_TREE,
   type Colony,
   type Settlement,
   type Unit,
@@ -4116,6 +4118,60 @@ describe('Edge cases: simultaneous actions (Issue #123)', () => {
     expect(result.actionResults[0].status).toBe('failed');
     expect(result.actionResults[0].result).toContain('already has a settlement');
     expect(result.newSettlements.length).toBe(0);
+  });
+
+  it('blocks Tier 2 research until all Tier 1 techs are complete', () => {
+    const colony = Object.assign(makeColony({
+      resources: { food: 500, timber: 500, stone: 500, iron: 500, influence: 500 },
+    }), {
+      researchedTechs: ['improved_agriculture', 'fortifications', 'advanced_scouting'],
+      researchQueue: [],
+    });
+    const settlement = makeSettlement({
+      colonyId: colony.id,
+      buildings: [{ type: 'workshop', level: 1 }],
+    });
+
+    const result = resolveResearch(
+      [colony],
+      [settlement],
+      [{ id: 'act-1', colonyId: colony.id, type: 'research', params: { techId: 'crop_rotation' } } as QueuedAction],
+    );
+
+    expect(result.actionResults[0].status).toBe('failed');
+    expect(result.actionResults[0].result).toContain('Tier 2 research is locked');
+    expect(result.actionResults[0].result).toContain(TECH_TREE.steel_weapons.name);
+    expect((colony as Colony & { researchQueue?: unknown[] }).researchQueue).toEqual([]);
+  });
+
+  it('unlocks Tier 2 research once all Tier 1 techs are complete', () => {
+    const colony = Object.assign(makeColony({
+      resources: { food: 500, timber: 500, stone: 500, iron: 500, influence: 500 },
+    }), {
+      researchedTechs: [
+        'improved_agriculture',
+        'fortifications',
+        'advanced_scouting',
+        'steel_weapons',
+        'trade_routes',
+        'siege_engineering',
+      ],
+      researchQueue: [],
+    });
+    const settlement = makeSettlement({
+      colonyId: colony.id,
+      buildings: [{ type: 'workshop', level: 1 }],
+    });
+
+    const result = resolveResearch(
+      [colony],
+      [settlement],
+      [{ id: 'act-2', colonyId: colony.id, type: 'research', params: { techId: 'civil_engineering' } } as QueuedAction],
+    );
+
+    expect(result.actionResults[0].status).toBe('resolved');
+    expect(result.actionResults[0].result).toContain(TECH_TREE.civil_engineering.name);
+    expect((colony as Colony & { researchQueue?: Array<{ techId: string }> }).researchQueue?.[0]?.techId).toBe('civil_engineering');
   });
 
 });

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -265,7 +265,19 @@ export interface ResearchQueueEntry {
   ticksRemaining: number;
 }
 
-export type TechId = 'improved_agriculture' | 'fortifications' | 'advanced_scouting' | 'steel_weapons' | 'trade_routes' | 'siege_engineering';
+export type TechId =
+  | 'improved_agriculture'
+  | 'fortifications'
+  | 'advanced_scouting'
+  | 'steel_weapons'
+  | 'trade_routes'
+  | 'siege_engineering'
+  | 'crop_rotation'
+  | 'metallurgy'
+  | 'cartography'
+  | 'professional_army'
+  | 'currency'
+  | 'civil_engineering';
 
 export interface TechDefinition {
   id: TechId;
@@ -273,6 +285,7 @@ export interface TechDefinition {
   description: string;
   cost: Partial<Resources>;
   ticks: number;
+  tier: 1 | 2;
   requires?: TechId[];
 }
 
@@ -283,6 +296,7 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: 'Farm production +30%',
     cost: { food: 200, timber: 100 },
     ticks: 10,
+    tier: 1,
   },
   fortifications: {
     id: 'fortifications',
@@ -290,6 +304,7 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: 'Settlement defense bonus — attackers take 2 damage per combat round',
     cost: { stone: 200, iron: 100, timber: 50 },
     ticks: 12,
+    tier: 1,
   },
   advanced_scouting: {
     id: 'advanced_scouting',
@@ -297,6 +312,7 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: 'Scout vision radius +3, scout movement speed +2',
     cost: { food: 150, timber: 100, iron: 50 },
     ticks: 8,
+    tier: 1,
   },
   steel_weapons: {
     id: 'steel_weapons',
@@ -304,6 +320,7 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: 'Militia and soldier combat power +2',
     cost: { iron: 200, stone: 100, timber: 50 },
     ticks: 15,
+    tier: 1,
     requires: ['fortifications'],
   },
   trade_routes: {
@@ -312,6 +329,7 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: '+5 influence per tick, +2 food per settlement beyond first',
     cost: { food: 150, timber: 100, influence: 50 },
     ticks: 10,
+    tier: 1,
     requires: ['improved_agriculture'],
   },
   siege_engineering: {
@@ -320,9 +338,97 @@ export const TECH_TREE: Record<TechId, TechDefinition> = {
     description: 'Siege units deal double damage to settlements',
     cost: { iron: 250, stone: 200, timber: 100 },
     ticks: 20,
+    tier: 1,
     requires: ['steel_weapons'],
   },
+  crop_rotation: {
+    id: 'crop_rotation',
+    name: 'Crop Rotation',
+    description: 'Unlocks the next agricultural growth tier.',
+    cost: { food: 300, timber: 150, iron: 50 },
+    ticks: 12,
+    tier: 2,
+    requires: ['improved_agriculture'],
+  },
+  metallurgy: {
+    id: 'metallurgy',
+    name: 'Metallurgy',
+    description: 'Unlocks advanced industrial refinement.',
+    cost: { iron: 300, stone: 200, timber: 150 },
+    ticks: 18,
+    tier: 2,
+    requires: ['fortifications'],
+  },
+  cartography: {
+    id: 'cartography',
+    name: 'Cartography',
+    description: 'Unlocks large-scale mapping and frontier surveying.',
+    cost: { food: 200, timber: 150, iron: 100 },
+    ticks: 12,
+    tier: 2,
+    requires: ['advanced_scouting'],
+  },
+  professional_army: {
+    id: 'professional_army',
+    name: 'Professional Army',
+    description: 'Unlocks more disciplined military organization.',
+    cost: { food: 400, iron: 300, stone: 200 },
+    ticks: 20,
+    tier: 2,
+    requires: ['steel_weapons'],
+  },
+  currency: {
+    id: 'currency',
+    name: 'Currency',
+    description: 'Unlocks more advanced trade and market coordination.',
+    cost: { food: 250, influence: 200, timber: 100 },
+    ticks: 14,
+    tier: 2,
+    requires: ['trade_routes'],
+  },
+  civil_engineering: {
+    id: 'civil_engineering',
+    name: 'Civil Engineering',
+    description: 'Unlocks advanced infrastructure planning and construction.',
+    cost: { stone: 250, timber: 200, iron: 100 },
+    ticks: 14,
+    tier: 2,
+    requires: ['siege_engineering'],
+  },
 };
+
+export const TIER_1_TECHS = Object.values(TECH_TREE)
+  .filter((tech) => tech.tier === 1)
+  .map((tech) => tech.id);
+
+export function canResearchTech(techId: TechId, researched: string[]): { ok: true } | { ok: false; reason: string } {
+  const tech = TECH_TREE[techId];
+  if (!tech) {
+    return { ok: false, reason: `Unknown tech: ${techId}` };
+  }
+
+  if (tech.tier > 1) {
+    const missingTierOne = TIER_1_TECHS.filter((id) => !researched.includes(id));
+    if (missingTierOne.length > 0) {
+      return {
+        ok: false,
+        reason: `Tier 2 research is locked until all Tier 1 techs are complete. Missing: ${missingTierOne.map((id) => TECH_TREE[id].name).join(', ')}`,
+      };
+    }
+  }
+
+  if (tech.requires) {
+    const missing = tech.requires.filter((id) => !researched.includes(id));
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        reason: `Missing prerequisite tech(s): ${missing.map((id) => TECH_TREE[id]?.name ?? id).join(', ')}`,
+      };
+    }
+  }
+
+  return { ok: true };
+}
 
 
 export interface TickResult {
@@ -3438,13 +3544,10 @@ export function resolveResearch(
     }
 
     // Check prerequisites
-    if (tech.requires) {
-      const missing = tech.requires.filter(r => !researched.includes(r));
-      if (missing.length > 0) {
-        const names = missing.map(id => TECH_TREE[id]?.name ?? id).join(', ');
-        actionResults.push({ actionId: action.id, status: 'failed', result: `Missing prerequisite tech(s): ${names}` });
-        continue;
-      }
+    const eligibility = canResearchTech(techId, researched);
+    if (!eligibility.ok) {
+      actionResults.push({ actionId: action.id, status: 'failed', result: eligibility.reason });
+      continue;
     }
 
     // Check not already in queue

--- a/src/routes/__tests__/actionsRoute.test.ts
+++ b/src/routes/__tests__/actionsRoute.test.ts
@@ -180,6 +180,40 @@ describe('Action submission route', () => {
     });
   });
 
+  it('rejects Tier 2 research submissions until all Tier 1 techs are complete', async () => {
+    mockDbSelectQueue([
+      [{ currentTick: 42, status: 'active', mapRadius: 12 }],
+      [{ count: 1 }],
+      [{ buildings: [{ type: 'workshop', level: 1 }] }],
+      [{ researchedTechs: ['improved_agriculture', 'fortifications', 'advanced_scouting'] }],
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/world-1/actions',
+      headers: {
+        authorization: 'Bearer rc_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      payload: {
+        actions: [
+          { type: 'research', params: { techId: 'crop_rotation' } },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: 'validation_error',
+      details: [
+        {
+          index: 0,
+          actionType: 'research',
+          error: expect.stringContaining('Tier 2 research is locked'),
+        },
+      ],
+    });
+  });
+
   it('scales action capacity with settlement count', async () => {
     mockDbSelectQueue([
       [{ currentTick: 42, status: 'active', mapRadius: 12 }],

--- a/src/routes/__tests__/stateRoute.test.ts
+++ b/src/routes/__tests__/stateRoute.test.ts
@@ -93,4 +93,39 @@ describe('State route intel', () => {
       },
     ]);
   });
+
+  it('shows Tier 2 techs as locked until all Tier 1 techs are researched', async () => {
+    mockDbSelectQueue([
+      [{
+        id: 'colony-1',
+        researchedTechs: ['improved_agriculture', 'fortifications', 'advanced_scouting'],
+        researchQueue: [],
+      }],
+    ]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds/world-1/tech',
+      headers: {
+        authorization: 'Bearer rc_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    const cropRotation = body.techs.find((tech: { id: string }) => tech.id === 'crop_rotation');
+    const steelWeapons = body.techs.find((tech: { id: string }) => tech.id === 'steel_weapons');
+
+    expect(cropRotation).toMatchObject({
+      id: 'crop_rotation',
+      tier: 2,
+      status: 'locked',
+      requires: ['improved_agriculture'],
+    });
+    expect(steelWeapons).toMatchObject({
+      id: 'steel_weapons',
+      tier: 1,
+      status: 'available',
+    });
+  });
 });

--- a/src/routes/actions.ts
+++ b/src/routes/actions.ts
@@ -13,7 +13,7 @@ import { nanoid } from 'nanoid';
 import { db } from '../db/index.js';
 import { worlds, actions, colonies, units, settlements } from '../db/schema/index.js';
 import { requireAuth } from '../middleware/index.js';
-import { normalizeAgreementTerms, type AgreementType } from '../engine/tick.js';
+import { normalizeAgreementTerms, TECH_TREE, canResearchTech, type AgreementType, type TechId } from '../engine/tick.js';
 
 // --- Types ---
 
@@ -613,6 +613,28 @@ async function validateActionContext(
 
   if (!hasWorkshop) {
     return { valid: false, error: 'You need a workshop building to research. Build a workshop first.' };
+  }
+
+  const colonyRows = await db
+    .select({ researchedTechs: colonies.researchedTechs })
+    .from(colonies)
+    .where(
+      and(
+        eq(colonies.worldId, worldId),
+        eq(colonies.id, colonyId),
+      ),
+    )
+    .limit(1);
+
+  const techId = action.params.techId as TechId | undefined;
+  if (!techId || !TECH_TREE[techId]) {
+    return { valid: false, error: `Unknown tech: ${techId}. Valid techs: ${Object.keys(TECH_TREE).join(', ')}` };
+  }
+
+  const researched: string[] = (colonyRows[0] as { researchedTechs?: string[] } | undefined)?.researchedTechs ?? [];
+  const eligibility = canResearchTech(techId, researched);
+  if (!eligibility.ok) {
+    return { valid: false, error: eligibility.reason };
   }
 
   return { valid: true };

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -10,7 +10,7 @@ import { eq, and, or, sql } from 'drizzle-orm';
 import { db } from '../db/index.js';
 import { worlds, hexes, colonies, settlements, units, agreements } from '../db/schema/index.js';
 import { requireAuth } from '../middleware/index.js';
-import { TECH_TREE, MIN_SETTLEMENT_DISTANCE } from '../engine/tick.js';
+import { TECH_TREE, MIN_SETTLEMENT_DISTANCE, canResearchTech } from '../engine/tick.js';
 import type { TechId } from '../engine/tick.js';
 import { hexDistance, hexNeighbors } from '../engine/hex.js';
 
@@ -525,12 +525,13 @@ export async function stateRoutes(app: FastifyInstance) {
       description: tech.description,
       cost: tech.cost,
       ticks: tech.ticks,
+      tier: tech.tier,
       requires: tech.requires ?? [],
       status: researched.includes(tech.id)
         ? 'researched'
         : queue.some(q => q.techId === tech.id)
           ? 'in_progress'
-          : (tech.requires ?? []).every(r => researched.includes(r))
+          : canResearchTech(tech.id, researched).ok
             ? 'available'
             : 'locked',
       ticksRemaining: queue.find(q => q.techId === tech.id)?.ticksRemaining ?? null,


### PR DESCRIPTION
Adds the Phase A Tier 2 tech tree definitions and gates Tier 2 research behind completion of all Tier 1 techs. This also mirrors the gate in action submission for immediate validation feedback and updates the authenticated tech endpoint to expose per-tech tier and the correct availability state.