### PR TITLE
fix: hide eliminated colony assets in public summaries

### DIFF
--- a/src/routes/__tests__/feed.test.ts
+++ b/src/routes/__tests__/feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { aggregateFeedEvents, buildSpectatorRecap, type SpectatorFeedEvent } from '../feed.js';
+import { aggregateFeedEvents, buildPublicColonySummary, buildSpectatorRecap, type SpectatorFeedEvent } from '../feed.js';
 
 describe('buildSpectatorRecap', () => {
   it('summarizes a mixed public event window into a recap', () => {
@@ -157,5 +157,56 @@ describe('aggregateFeedEvents', () => {
     expect(aggregated[0].groupedCount).toBe(2);
     expect(aggregated[0].summary).toContain('activity update');
     expect(aggregated[0].groupedTypes).toEqual(expect.arrayContaining(['build_complete', 'build_started']));
+  });
+});
+
+describe('buildPublicColonySummary', () => {
+  it('zeros live assets for eliminated colonies in public summaries', () => {
+    const summary = buildPublicColonySummary(
+      {
+        id: 'col_a',
+        name: 'Fallen Colony',
+        status: 'eliminated',
+        legacyScore: 88,
+      },
+      [
+        { colonyId: 'col_a', tier: 'outpost' },
+        { colonyId: 'col_a', tier: 'town' },
+      ],
+      [
+        { colonyId: 'col_a', type: 'soldier' },
+        { colonyId: 'col_a', type: 'militia' },
+      ],
+    );
+
+    expect(summary.legacyScore).toBe(88);
+    expect(summary.settlements).toBe(0);
+    expect(summary.units).toBe(0);
+    expect(summary.settlementTiers).toEqual({ outpost: 0, town: 0, city: 0 });
+    expect(summary.unitTypes).toEqual({ scout: 0, militia: 0, soldier: 0, siege: 0, settler: 0 });
+  });
+
+  it('keeps active colony assets visible in public summaries', () => {
+    const summary = buildPublicColonySummary(
+      {
+        id: 'col_a',
+        name: 'Frontier Colony',
+        status: 'active',
+        legacyScore: 42,
+      },
+      [
+        { colonyId: 'col_a', tier: 'outpost' },
+        { colonyId: 'col_a', tier: 'town' },
+      ],
+      [
+        { colonyId: 'col_a', type: 'soldier' },
+        { colonyId: 'col_a', type: 'militia' },
+      ],
+    );
+
+    expect(summary.settlements).toBe(2);
+    expect(summary.units).toBe(2);
+    expect(summary.settlementTiers).toEqual({ outpost: 1, town: 1, city: 0 });
+    expect(summary.unitTypes).toEqual({ scout: 0, militia: 1, soldier: 1, siege: 0, settler: 0 });
   });
 });

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -43,11 +43,63 @@ export interface SpectatorRecap {
   highlights: string[];
 }
 
+interface PublicColonySummaryInput {
+  id: string;
+  name: string;
+  status: string;
+  legacyScore: number | null;
+}
+
+interface PublicSettlementRow {
+  colonyId: string;
+  tier: string;
+}
+
+interface PublicUnitRow {
+  colonyId: string;
+  type?: string;
+}
+
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
 function pluralize(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function isLiveColonyStatus(status: string): boolean {
+  return status === 'active' || status === 'full';
+}
+
+export function buildPublicColonySummary(
+  colony: PublicColonySummaryInput,
+  settlementRows: PublicSettlementRow[],
+  unitRows: PublicUnitRow[],
+) {
+  const live = isLiveColonyStatus(colony.status);
+  const mySettlements = live ? settlementRows.filter((s) => s.colonyId === colony.id) : [];
+  const myUnits = live ? unitRows.filter((u) => u.colonyId === colony.id) : [];
+
+  return {
+    id: colony.id,
+    name: colony.name,
+    status: colony.status,
+    legacyScore: colony.legacyScore ?? 0,
+    settlements: mySettlements.length,
+    settlementTiers: {
+      outpost: mySettlements.filter((s) => s.tier === 'outpost').length,
+      town: mySettlements.filter((s) => s.tier === 'town').length,
+      city: mySettlements.filter((s) => s.tier === 'city').length,
+    },
+    units: myUnits.length,
+    unitTypes: {
+      scout: myUnits.filter((u) => u.type === 'scout').length,
+      militia: myUnits.filter((u) => u.type === 'militia').length,
+      soldier: myUnits.filter((u) => u.type === 'soldier').length,
+      siege: myUnits.filter((u) => u.type === 'siege').length,
+      settler: myUnits.filter((u) => u.type === 'settler').length,
+    },
+  };
 }
 
 function getEventImportance(event: SpectatorFeedEvent): 'high' | 'normal' | 'low' {
@@ -414,31 +466,7 @@ export async function feedRoutes(app: FastifyInstance) {
       .where(eq(units.worldId, worldId));
 
     // Build colony summaries
-    const colonySummaries = colonyRows.map((c) => {
-      const mySettlements = settlementRows.filter(s => s.colonyId === c.id);
-      const myUnits = unitRows.filter(u => u.colonyId === c.id);
-
-      return {
-        id: c.id,
-        name: c.name,
-        status: c.status,
-        legacyScore: c.legacyScore,
-        settlements: mySettlements.length,
-        settlementTiers: {
-          outpost: mySettlements.filter(s => s.tier === 'outpost').length,
-          town: mySettlements.filter(s => s.tier === 'town').length,
-          city: mySettlements.filter(s => s.tier === 'city').length,
-        },
-        units: myUnits.length,
-        unitTypes: {
-          scout: myUnits.filter(u => u.type === 'scout').length,
-          militia: myUnits.filter(u => u.type === 'militia').length,
-          soldier: myUnits.filter(u => u.type === 'soldier').length,
-          siege: myUnits.filter(u => u.type === 'siege').length,
-          settler: myUnits.filter(u => u.type === 'settler').length,
-        },
-      };
-    });
+    const colonySummaries = colonyRows.map((c) => buildPublicColonySummary(c, settlementRows, unitRows));
 
     return {
       world: {
@@ -567,15 +595,13 @@ export async function feedRoutes(app: FastifyInstance) {
       .where(eq(units.worldId, worldId));
 
     const ranked = colonyRows.map((c) => {
-      const mySettlements = settlementRows.filter(s => s.colonyId === c.id);
-      const myUnits = unitRows.filter(u => u.colonyId === c.id);
-
+      const summary = buildPublicColonySummary(c, settlementRows, unitRows);
       return {
-        name: c.name,
-        status: c.status,
-        legacyScore: c.legacyScore ?? 0,
-        settlements: mySettlements.length,
-        units: myUnits.length,
+        name: summary.name,
+        status: summary.status,
+        legacyScore: summary.legacyScore,
+        settlements: summary.settlements,
+        units: summary.units,
         founded: c.createdAt,
       };
     })


### PR DESCRIPTION
Fixes the public colony cards and leaderboard so eliminated or dead colonies no longer appear to have live settlements or units. The change keeps their final legacy score visible, but zeros active asset counts in public summaries to match gameplay reality and avoid misleading rankings.