### PR TITLE
fix: expose visible enemy intel in map

### DIFF
--- a/src/routes/__tests__/stateRoute.test.ts
+++ b/src/routes/__tests__/stateRoute.test.ts
@@ -153,6 +153,7 @@ describe('State route intel', () => {
           poi: null,
         },
       ],
+      [],
     ]);
 
     const response = await app.inject({
@@ -174,6 +175,68 @@ describe('State route intel', () => {
           roads: [{ toX: 5, toY: 2, status: 'built' }],
         }),
       ]),
+    });
+  });
+
+  it('includes visible enemy units and settlements in the map response', async () => {
+    mockDbSelectQueue([
+      [{ currentTick: 778 }],
+      [],
+      [
+        { x: 36, y: -21, terrain: 'plains', resources: { food: 3 }, settlementId: 'set-enemy', roads: {}, poi: null },
+        { x: 40, y: -17, terrain: 'plains', resources: { food: 2 }, settlementId: null, roads: {}, poi: null },
+      ],
+      [
+        { id: 'enemy-1', colonyId: 'colony-2', type: 'soldier', hexX: 36, hexY: -21, health: 72 },
+        { id: 'enemy-2', colonyId: 'colony-2', type: 'soldier', hexX: 40, hexY: -17, health: 91 },
+      ],
+      [
+        { id: 'set-enemy', colonyId: 'colony-2', name: 'Iron Horde Prime', hexX: 36, hexY: -21, tier: 'town' },
+      ],
+      [
+        { id: 'colony-2', name: 'Iron Horde' },
+      ],
+    ]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/worlds/world-1/map',
+      headers: {
+        authorization: 'Bearer rc_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      tick: 778,
+      enemyUnits: [
+        {
+          id: 'enemy-1',
+          colonyId: 'colony-2',
+          type: 'soldier',
+          hex: { x: 36, y: -21 },
+          health: 72,
+        },
+        {
+          id: 'enemy-2',
+          colonyId: 'colony-2',
+          type: 'soldier',
+          hex: { x: 40, y: -17 },
+          health: 91,
+        },
+      ],
+      settlements: [
+        {
+          id: 'set-enemy',
+          colonyId: 'colony-2',
+          name: 'Iron Horde Prime',
+          hex: { x: 36, y: -21 },
+          tier: 'town',
+        },
+      ],
+      knownColonies: {
+        'colony-2': 'Iron Horde',
+      },
     });
   });
 });

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -58,6 +58,28 @@ export interface SettlementSiteCandidate {
   reasons: string[];
 }
 
+interface VisibleEnemyUnit {
+  id: string;
+  colonyId: string;
+  type: string;
+  hex: { x: number; y: number };
+  health: number;
+}
+
+interface VisibleEnemySettlement {
+  id: string;
+  colonyId: string;
+  name: string;
+  hex: { x: number; y: number };
+  tier: string;
+}
+
+interface VisibleIntelSummary {
+  enemyUnits: VisibleEnemyUnit[];
+  enemySettlements: VisibleEnemySettlement[];
+  knownColonies: Record<string, string>;
+}
+
 export function analyzeSettlementSites(
   visibleHexes: VisibleHex[],
   limit = 5,
@@ -155,6 +177,107 @@ export function analyzeSettlementSites(
       return a.y - b.y;
     })
     .slice(0, limit);
+}
+
+async function getVisibleEnemyIntel(
+  worldId: string,
+  colonyId: string,
+  visibleMap: VisibleHex[],
+): Promise<VisibleIntelSummary> {
+  const visibleCoords = visibleMap.map(h => ({ x: h.x, y: h.y }));
+  if (visibleCoords.length === 0) {
+    return {
+      enemyUnits: [],
+      enemySettlements: [],
+      knownColonies: {},
+    };
+  }
+
+  const visibleSet = new Set(visibleCoords.map(c => `${c.x},${c.y}`));
+
+  const allVisibleUnits = await db
+    .select({
+      id: units.id,
+      colonyId: units.colonyId,
+      type: units.type,
+      hexX: units.hexX,
+      hexY: units.hexY,
+      health: units.health,
+    })
+    .from(units)
+    .where(
+      and(
+        eq(units.worldId, worldId),
+        sql`${units.colonyId} != ${colonyId}`,
+      ),
+    );
+
+  const enemyUnits = allVisibleUnits
+    .filter(u => u.health > 0 && visibleSet.has(`${u.hexX},${u.hexY}`))
+    .map(u => ({
+      id: u.id,
+      colonyId: u.colonyId,
+      type: u.type,
+      hex: { x: u.hexX, y: u.hexY },
+      health: u.health,
+    }));
+
+  const visibleSettlementIds = visibleMap
+    .filter(h => h.settlementId !== null)
+    .map(h => h.settlementId!);
+
+  let enemySettlements: VisibleEnemySettlement[] = [];
+  if (visibleSettlementIds.length > 0) {
+    const allSettlements = await db
+      .select({
+        id: settlements.id,
+        colonyId: settlements.colonyId,
+        name: settlements.name,
+        hexX: settlements.hexX,
+        hexY: settlements.hexY,
+        tier: settlements.tier,
+      })
+      .from(settlements)
+      .where(
+        and(
+          eq(settlements.worldId, worldId),
+          sql`${settlements.colonyId} != ${colonyId}`,
+        ),
+      );
+
+    enemySettlements = allSettlements
+      .filter(s => visibleSet.has(`${s.hexX},${s.hexY}`))
+      .map(s => ({
+        id: s.id,
+        colonyId: s.colonyId,
+        name: s.name,
+        hex: { x: s.hexX, y: s.hexY },
+        tier: s.tier,
+      }));
+  }
+
+  const enemyColonyIds = new Set([
+    ...enemyUnits.map(u => u.colonyId),
+    ...enemySettlements.map(s => s.colonyId),
+  ]);
+
+  let knownColonies: Record<string, string> = {};
+  if (enemyColonyIds.size > 0) {
+    const colRows = await db
+      .select({ id: colonies.id, name: colonies.name })
+      .from(colonies)
+      .where(eq(colonies.worldId, worldId));
+
+    knownColonies = Object.fromEntries(
+      colRows.filter(c => enemyColonyIds.has(c.id)).map(c => [c.id, c.name]),
+    );
+  }
+
+  return {
+    enemyUnits,
+    enemySettlements,
+    knownColonies,
+  };
 }
 
 /**
@@ -283,92 +406,8 @@ export async function stateRoutes(app: FastifyInstance) {
       .where(eq(worlds.id, worldId))
       .limit(1);
 
-    // Find enemy units and settlements on visible hexes
-    const visibleCoords = visibleMap.map(h => ({ x: h.x, y: h.y }));
-    let enemyUnitsOnMap: Array<{ id: string; colonyId: string; type: string; hex: { x: number; y: number }; health: number }> = [];
-    let enemySettlementsOnMap: Array<{ id: string; colonyId: string; name: string; hex: { x: number; y: number }; tier: string }> = [];
-
-    if (visibleCoords.length > 0) {
-      // Get all enemy units on hexes visible to this colony
-      const allVisibleUnits = await db
-        .select({
-          id: units.id,
-          colonyId: units.colonyId,
-          type: units.type,
-          hexX: units.hexX,
-          hexY: units.hexY,
-          health: units.health,
-        })
-        .from(units)
-        .where(
-          and(
-            eq(units.worldId, worldId),
-            sql`${units.colonyId} != ${colony.id}`,
-          ),
-        );
-
-      // Filter to only units on visible hexes
-      const visibleSet = new Set(visibleCoords.map(c => `${c.x},${c.y}`));
-      enemyUnitsOnMap = allVisibleUnits
-        .filter(u => u.health > 0 && visibleSet.has(`${u.hexX},${u.hexY}`))
-        .map(u => ({
-          id: u.id,
-          colonyId: u.colonyId,
-          type: u.type,
-          hex: { x: u.hexX, y: u.hexY },
-          health: u.health,
-        }));
-
-      // Get enemy settlements on visible hexes
-      const visibleSettlementIds = visibleMap
-        .filter(h => h.settlementId !== null)
-        .map(h => h.settlementId!);
-
-      if (visibleSettlementIds.length > 0) {
-        const allSettlements = await db
-          .select({
-            id: settlements.id,
-            colonyId: settlements.colonyId,
-            name: settlements.name,
-            hexX: settlements.hexX,
-            hexY: settlements.hexY,
-            tier: settlements.tier,
-          })
-          .from(settlements)
-          .where(
-            and(
-              eq(settlements.worldId, worldId),
-              sql`${settlements.colonyId} != ${colony.id}`,
-            ),
-          );
-
-        enemySettlementsOnMap = allSettlements
-          .filter(s => visibleSet.has(`${s.hexX},${s.hexY}`))
-          .map(s => ({
-            id: s.id,
-            colonyId: s.colonyId,
-            name: s.name,
-            hex: { x: s.hexX, y: s.hexY },
-            tier: s.tier,
-          }));
-      }
-    }
-
-    // Get colony names for enemy reference
-    const enemyColonyIds = new Set([
-      ...enemyUnitsOnMap.map(u => u.colonyId),
-      ...enemySettlementsOnMap.map(s => s.colonyId),
-    ]);
-    let knownColonies: Record<string, string> = {};
-    if (enemyColonyIds.size > 0) {
-      const colRows = await db
-        .select({ id: colonies.id, name: colonies.name })
-        .from(colonies)
-        .where(eq(colonies.worldId, worldId));
-      knownColonies = Object.fromEntries(
-        colRows.filter(c => enemyColonyIds.has(c.id)).map(c => [c.id, c.name]),
-      );
-    }
+    const intelSummary = await getVisibleEnemyIntel(worldId, colony.id, visibleMap);
+    let knownColonies: Record<string, string> = { ...intelSummary.knownColonies };
 
     // Load agreements involving this colony
     const colonyAgreements = await db
@@ -463,8 +502,8 @@ export async function stateRoutes(app: FastifyInstance) {
         movementQueue: u.movementQueue,
       })),
       intel: {
-        enemyUnits: enemyUnitsOnMap,
-        enemySettlements: enemySettlementsOnMap,
+        enemyUnits: intelSummary.enemyUnits,
+        enemySettlements: intelSummary.enemySettlements,
         knownColonies,
       },
       map: visibleMap,
@@ -488,12 +527,16 @@ export async function stateRoutes(app: FastifyInstance) {
     }
 
     const visibleMap = await getVisibleHexes(colony.worldId, colony.id);
+    const intelSummary = await getVisibleEnemyIntel(colony.worldId, colony.id, visibleMap);
 
     return {
       tick: world[0].currentTick,
       colonyId: colony.id,
       hexCount: visibleMap.length,
       hexes: visibleMap,
+      enemyUnits: intelSummary.enemyUnits,
+      settlements: intelSummary.enemySettlements,
+      knownColonies: intelSummary.knownColonies,
     };
   });
 


### PR DESCRIPTION
Fixes /api/worlds/:id/map so visible enemy units and enemy settlements appear when they are on visible hexes, including active combat fronts.

Closes #307.