### PR TITLE
fix: reject unknown research tech ids

### DIFF
--- a/src/routes/__tests__/actionsRoute.test.ts
+++ b/src/routes/__tests__/actionsRoute.test.ts
@@ -111,6 +111,13 @@ describe('Action submission route', () => {
             },
           },
         },
+        research: {
+          params: {
+            techId: {
+              validValues: expect.arrayContaining(['improved_agriculture', 'civil_engineering']),
+            },
+          },
+        },
         build_road: {
           required: ['unitId', 'fromX', 'fromY', 'toX', 'toY'],
         },
@@ -185,6 +192,41 @@ describe('Action submission route', () => {
           index: 0,
           actionType: 'research',
           error: 'You need a workshop building to research. Build a workshop first.',
+        },
+      ],
+    });
+  });
+
+  it('rejects research submissions with an unknown techId immediately', async () => {
+    mockDbSelectQueue([
+      [{ currentTick: 42, status: 'active', mapRadius: 12 }],
+      [{ count: 1 }],
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/worlds/world-1/actions',
+      headers: {
+        authorization: 'Bearer rc_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      payload: {
+        actions: [
+          { type: 'research', params: { techId: 'test_invalid' } },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: 'validation_error',
+      details: [
+        {
+          index: 0,
+          actionType: 'research',
+          error: expect.stringContaining("Unknown techId 'test_invalid'. Valid:"),
+          help: {
+            validValues: expect.arrayContaining(['improved_agriculture', 'civil_engineering']),
+          },
         },
       ],
     });

--- a/src/routes/actions.ts
+++ b/src/routes/actions.ts
@@ -200,7 +200,7 @@ const ACTION_DEFINITIONS: Record<string, ActionDefinition> = {
     required: ['techId'],
     optional: [],
     params: {
-      techId: { type: 'string', description: 'Technology identifier to research.' },
+      techId: { type: 'string', description: 'Technology identifier to research.', validValues: Object.keys(TECH_TREE) },
     },
   },
   propose_agreement: {
@@ -529,6 +529,13 @@ function validateActionParams(action: ActionInput, mapRadius: number): Validatio
   if (action.type === 'research') {
     if (typeof p.techId !== 'string' || p.techId.length === 0) {
       return { valid: false, error: `'techId' must be a non-empty string` };
+    }
+    if (!TECH_TREE[p.techId as TechId]) {
+      return {
+        valid: false,
+        error: `Unknown techId '${p.techId}'. Valid: ${Object.keys(TECH_TREE).join(', ')}`,
+        help: { validValues: Object.keys(TECH_TREE) },
+      };
     }
   }
 


### PR DESCRIPTION
Adds immediate validation for invalid research tech IDs and exposes valid tech IDs in the action schema.

This prevents players from wasting action slots on unknown tech identifiers and makes the valid research options discoverable through the API.

Closes #314