### PR TITLE
fix: stop marking combat units idle

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -3256,6 +3256,49 @@ describe('Idle unit tracking', () => {
     expect(updatedUnit.idleTicks).toBe(4);
   });
 
+  it('does not mark frontline combatants idle when they fight this tick', () => {
+    const attacker = makeUnit({ id: 'soldier-1', type: 'soldier', idleTicks: 2, hexX: 0, hexY: 0 });
+    const defender = makeUnit({ id: 'soldier-2', colonyId: 'colony-2', type: 'soldier', hexX: 0, hexY: 0 });
+
+    const result = resolveTick(
+      [makeColony(), makeColony({ id: 'colony-2', name: 'Enemy Colony' })],
+      [],
+      [attacker, defender],
+      makeHexRing(0, 0),
+      [],
+      42,
+      'world-1',
+      5,
+    );
+
+    expect(result.events.find(e => e.type === 'unit_idle' && e.unitId === 'soldier-1')).toBeUndefined();
+    expect(result.units.find(u => u.id === 'soldier-1')?.idleTicks).toBe(0);
+  });
+
+  it('does not mark adjacent support combatants idle when they join a full battle', () => {
+    const attackerColony = makeColony({ id: 'colony-1' });
+    const defenderColony = makeColony({ id: 'colony-2', name: 'Enemy Colony' });
+    const frontlineAttacker = makeUnit({ id: 'frontline', colonyId: 'colony-1', type: 'soldier', hexX: 1, hexY: 0 });
+    const supportAttacker = makeUnit({ id: 'support', colonyId: 'colony-1', type: 'soldier', hexX: 0, hexY: 0, idleTicks: 2 });
+    const defenders = Array.from({ length: MAX_UNITS_PER_HEX - 1 }, (_, i) =>
+      makeUnit({ id: `defender-${i}`, colonyId: 'colony-2', type: 'soldier', hexX: 1, hexY: 0 }),
+    );
+
+    const result = resolveTick(
+      [attackerColony, defenderColony],
+      [makeSettlement({ id: 'settlement-2', colonyId: 'colony-2', hexX: 1, hexY: 0, population: 10 })],
+      [frontlineAttacker, supportAttacker, ...defenders],
+      makePlainLine(1),
+      [makeAction({ colonyId: 'colony-1', params: { unitId: 'support', targetX: 1, targetY: 0 } })],
+      123,
+      'world-1',
+      50,
+    );
+
+    expect(result.events.find(e => e.type === 'unit_idle' && e.unitId === 'support')).toBeUndefined();
+    expect(result.units.find(u => u.id === 'support')?.idleTicks).toBe(0);
+  });
+
   it('newly trained units start with idleTicks 0', () => {
     const colony = makeColony({ resources: { food: 200, timber: 100, stone: 50, iron: 20, influence: 50 } });
     const settlement = makeSettlement({

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -4520,6 +4520,7 @@ export function resolveTick(
   let newMessages: MessageRecord[] = [];
   let agreementMutations: AgreementMutation[] = [];
   const combatHexesThisTick = new Set<string>();
+  const combatParticipantIdsThisTick = new Set<string>();
   const capturedSettlementIdsThisTick = new Set<string>();
 
   // --- Agreement resolution (before other actions) ---
@@ -4915,6 +4916,14 @@ export function resolveTick(
       }));
       events.push(...combatResult.events);
       actionResults.push(...combatResult.actionResults);
+
+      for (const event of combatResult.events) {
+        if (event.type !== 'combat_resolved') continue;
+        const participants = (event.data as { participants?: Array<{ unitId: string }> }).participants ?? [];
+        for (const participant of participants) {
+          combatParticipantIdsThisTick.add(participant.unitId);
+        }
+      }
     }
 
     // Handle settlement captures: award legacy score, check for colony elimination
@@ -5701,8 +5710,9 @@ export function resolveTick(
     const moved = before.x !== unit.hexX || before.y !== unit.hexY;
     const hasQueue = unit.movementQueue && unit.movementQueue.length > 0;
     const hadAction = unitActionTargets.has(unit.id);
+    const foughtThisTick = combatParticipantIdsThisTick.has(unit.id);
 
-    if (moved || hasQueue || hadAction) {
+    if (moved || hasQueue || hadAction || foughtThisTick) {
       unit.idleTicks = 0;
     } else {
       unit.idleTicks = (unit.idleTicks ?? 0) + 1;


### PR DESCRIPTION
Prevents idle warnings for units that actually fought this tick, including adjacent support combatants on full contested hexes.

This keeps the idle signal aligned with battlefield reality: if a unit participated in combat, it should not be treated as inactive.

Closes #313