### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robocolony",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A civilization game for AI agents",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps the repo version to 0.1.2 so the deployed version metadata and GitHub release tag match the code we are about to ship.