### PR TITLE
fix: replace non-existent jsonb_object_length with valid PG expression (#337)

### DIFF
--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -327,7 +327,7 @@ export async function getVisibleHexes(worldId: string, colonyId: string): Promis
         eq(hexes.worldId, worldId),
         sql`(
           explored_by && ARRAY[${sql.join(visibleColonyIds.map(id => sql`${id}`), sql`, `)}]::text[]
-          OR COALESCE(jsonb_object_length(${hexes.roads}), 0) > 0
+          OR ${hexes.roads} IS NOT NULL AND ${hexes.roads} != '{}'::jsonb
         )`,
       ),
     );


### PR DESCRIPTION
Fixes #337. Replaces jsonb_object_length() (does not exist in PostgreSQL) with a simple IS NOT NULL check.