### PR TITLE
fix: add maxHp and status fields to unit responses in /state endpoint (#324)

### DIFF
--- a/src/routes/__tests__/state.test.ts
+++ b/src/routes/__tests__/state.test.ts
@@ -90,7 +90,9 @@ describe('State response shape', () => {
         type: 'scout',
         hex: { x: 10, y: -5 },
         health: 100,
+        maxHp: 100,
         morale: 1.0,
+        status: 'idle',
         movementQueue: [],
       }],
       map: [{

--- a/src/routes/__tests__/stateRoute.test.ts
+++ b/src/routes/__tests__/stateRoute.test.ts
@@ -90,6 +90,7 @@ describe('State route intel', () => {
         type: 'soldier',
         hex: { x: 5, y: 5 },
         health: 80,
+        maxHp: 100,
       },
     ]);
   });
@@ -216,6 +217,7 @@ describe('State route intel', () => {
           type: 'soldier',
           hex: { x: 36, y: -21 },
           health: 72,
+          maxHp: 100,
         },
         {
           id: 'enemy-2',
@@ -223,6 +225,7 @@ describe('State route intel', () => {
           type: 'soldier',
           hex: { x: 40, y: -17 },
           health: 91,
+          maxHp: 100,
         },
       ],
       settlements: [

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -64,6 +64,7 @@ interface VisibleEnemyUnit {
   type: string;
   hex: { x: number; y: number };
   health: number;
+  maxHp: number;
 }
 
 interface VisibleEnemySettlement {
@@ -220,6 +221,7 @@ async function getVisibleEnemyIntel(
       type: u.type,
       hex: { x: u.hexX, y: u.hexY },
       health: u.health,
+      maxHp: 100,
     }));
 
   const visibleSettlementIds = visibleMap
@@ -498,7 +500,9 @@ export async function stateRoutes(app: FastifyInstance) {
         type: u.type,
         hex: { x: u.hexX, y: u.hexY },
         health: u.health,
+        maxHp: 100,
         morale: u.morale,
+        status: (u.movementQueue as unknown[])?.length > 0 ? 'moving' : 'idle',
         movementQueue: u.movementQueue,
       })),
       intel: {


### PR DESCRIPTION
## Changes

Adds missing `maxHp` and `status` fields to unit objects returned by `/api/worlds/:id/state`.

### Colony units
- `maxHp: 100` — all units currently have max HP of 100
- `status: "idle" | "moving"` — derived from movement queue length

### Enemy units (intel)
- `maxHp: 100` — added to intel enemy unit objects

### Tests
- Updated `state.test.ts` mock to include new fields
- Updated `stateRoute.test.ts` assertions for enemy unit shape

Closes #324