### PR TITLE
fix: persist unitId/settlementId/colonyId into event data column (#344)

### DIFF
--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -810,11 +810,18 @@ export class TickScheduler {
             }
           }
 
+          // Merge top-level TickEvent fields (colonyId, settlementId, unitId)
+          // into data so they are persisted and visible in the events API.
+          const enrichedData: Record<string, unknown> = { ...event.data };
+          if (event.colonyId) enrichedData.colonyId ??= event.colonyId;
+          if (event.settlementId) enrichedData.settlementId ??= event.settlementId;
+          if (event.unitId) enrichedData.unitId ??= event.unitId;
+
           const persistedEvent = {
             type: event.type,
             public: isPublic,
             visibility: eventVisibility(event),
-            data: event.data,
+            data: enrichedData,
             ...(publicData ? { publicData } : {}),
           };
 


### PR DESCRIPTION
## Problem

`unit_trained` events (and many others) carry `unitId`, `settlementId`, and `colonyId` as top-level `TickEvent` fields, but the scheduler only persists `event.data` to the database. These fields are silently dropped, making them invisible in the events API.

This means players cannot discover newly trained unit IDs from events.

## Fix

In the scheduler event persistence loop, merge `colonyId`, `settlementId`, and `unitId` from the TickEvent into the `data` object before storage. Uses `??=` to avoid overwriting if these fields already exist in data.

This enriches all events across the board, not just `unit_trained`.

## Testing

Existing tests continue to pass. The change is additive — it only adds fields that were previously lost.

Closes #344