### PR TITLE
fix: add npm run build to startup.sh for deploy-time compilation

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -3,5 +3,6 @@ set -ex
 apk add --no-cache git
 cd /data/robocolony
 git pull origin main
-npm install --omit=dev 2>&1
+npm install
+npm run build
 NODE_ENV=production exec node dist/server.js


### PR DESCRIPTION
## Problem

The `publish-build-artifacts` CI job fails on every merge because branch protection rules prevent direct pushes to main:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Required status check "verify" is expected.
remote: - Changes must be made through a pull request.
```

This means the compiled `dist/` files in the repo are stale, and deploying via `startup.sh` (`git pull` + `node dist/server.js`) runs old code.

## Fix

Update `startup.sh` to run `npm install` (with devDeps) and `npm run build` after `git pull`. This compiles TypeScript at deploy time, so the server always runs the latest code.

This is a simpler fix than trying to bypass branch protection for CI, and ensures correctness regardless of CI pipeline status.