### PR TITLE
fix: preserve persisted movement queues

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -1864,6 +1864,31 @@ describe('resolveTick', () => {
     expect(result3.units[0].movementQueue).toEqual([]);
   });
 
+  it('continues draining persisted movement queues that use legacy x/y coordinates', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ population: 0 });
+    const hexes = makePlainLine(8);
+
+    const persistedQueue = [
+      { x: 4, y: 0 },
+      { x: 5, y: 0 },
+      { x: 6, y: 0 },
+    ];
+    const units = [
+      makeUnit({
+        hexX: 3,
+        hexY: 0,
+        type: 'militia',
+        movementQueue: persistedQueue as unknown as Unit['movementQueue'],
+      }),
+    ];
+
+    const result = resolveTick([colony], [settlement], units, hexes);
+
+    expect(result.units[0].hexX).toBe(6);
+    expect(result.units[0].movementQueue).toEqual([]);
+  });
+
   // --- Settlement founding integration in resolveTick ---
 
   it('resolves found_settlement in tick and adds new settlement to results', () => {

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -141,6 +141,31 @@ function coordKey(coord: HexCoord): string {
   return `${coord.q},${coord.r}`;
 }
 
+function normalizeMovementQueue(queue: unknown): HexCoord[] {
+  if (!Array.isArray(queue)) return [];
+
+  return queue
+    .map((step) => {
+      if (!step || typeof step !== 'object') return null;
+
+      const candidate = step as { q?: unknown; r?: unknown; x?: unknown; y?: unknown };
+      const q = typeof candidate.q === 'number'
+        ? candidate.q
+        : typeof candidate.x === 'number'
+          ? candidate.x
+          : null;
+      const r = typeof candidate.r === 'number'
+        ? candidate.r
+        : typeof candidate.y === 'number'
+          ? candidate.y
+          : null;
+
+      if (!Number.isFinite(q) || !Number.isFinite(r)) return null;
+      return { q, r };
+    })
+    .filter((step): step is HexCoord => step !== null);
+}
+
 function chooseScoutDestination(
   from: HexCoord,
   desired: HexCoord,
@@ -2504,6 +2529,7 @@ export function resolveMovement(
   // Build unit lookup for ownership/existence checks
   const unitMap = new Map<string, Unit>();
   for (const u of units) {
+    u.movementQueue = normalizeMovementQueue(u.movementQueue);
     unitMap.set(u.id, u);
     const key = hexKey(u.hexX, u.hexY);
     occupancy.set(key, (occupancy.get(key) ?? 0) + 1);
@@ -4637,7 +4663,7 @@ export function resolveTick(
   // Deep clone units so we can mutate
   let updatedUnits = units.map(u => ({
     ...u,
-    movementQueue: u.movementQueue ? [...u.movementQueue] : [],
+    movementQueue: normalizeMovementQueue(u.movementQueue),
   }));
 
   // Deep clone settlements so we can mutate (including buildQueue)
@@ -4686,7 +4712,7 @@ export function resolveTick(
 
     updatedUnits = foundResult.units.map(u => ({
       ...u,
-      movementQueue: u.movementQueue ? [...u.movementQueue] : [],
+      movementQueue: normalizeMovementQueue(u.movementQueue),
     }));
     updatedSettlements = [...updatedSettlements, ...foundResult.newSettlements];
     events.push(...foundResult.events);
@@ -4701,7 +4727,7 @@ export function resolveTick(
     const disbandResult = resolveDisband(updatedUnits, actions);
     updatedUnits = disbandResult.units.map(u => ({
       ...u,
-      movementQueue: u.movementQueue ? [...u.movementQueue] : [],
+      movementQueue: normalizeMovementQueue(u.movementQueue),
     }));
     events.push(...disbandResult.events);
     actionResults.push(...disbandResult.actionResults);
@@ -4920,7 +4946,7 @@ export function resolveTick(
     if (combatResult.destroyedUnitIds.length > 0 || combatResult.events.length > 0) {
       updatedUnits = combatResult.units.map(u => ({
         ...u,
-        movementQueue: u.movementQueue ? [...u.movementQueue] : [],
+        movementQueue: normalizeMovementQueue(u.movementQueue),
       }));
       events.push(...combatResult.events);
       actionResults.push(...combatResult.actionResults);


### PR DESCRIPTION
## What does this PR do?

Fixes movement orders getting lost mid-journey by normalizing persisted movement queues before the tick engine drains them.

The movement engine expects queue steps in q/r form, but older or inconsistent persisted queue entries can be shaped like x/y. When that happened, the next tick treated the first step as impassable and cleared the whole queue, leaving units idle partway to their destination.

This change accepts both shapes, filters invalid entries defensively, and adds a regression test that starts from persisted queue data rather than a fresh move action.

## Related issue

Closes #350

## How to test

1. Run the targeted tick movement tests
2. Run the full Vitest suite
3. Run TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits