### PR TITLE
fix: avoid duplicate action failure events

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -1814,6 +1814,28 @@ describe('resolveTick', () => {
     expect(result.units[0].hexX).toBe(0); // didn't move
   });
 
+  it('does not emit duplicate action_failed events for failed actions', () => {
+    const colony = makeColony();
+    const settlement = makeSettlement({ population: 0 });
+    const hexes = [
+      makeHex(0, 0),
+      makeHex(1, 0, { terrain: 'ocean' }),
+      makeHex(2, 0),
+    ];
+    const units = [makeUnit({ hexX: 0, hexY: 0 })];
+    const actions: QueuedAction[] = [
+      makeAction({ params: { unitId: 'unit-1', targetX: 2, targetY: 0 } }),
+    ];
+
+    const result = resolveTick([colony], [settlement], units, hexes, actions);
+
+    expect(result.actionResults[0]).toMatchObject({
+      actionId: actions[0].id,
+      status: 'failed',
+    });
+    expect(result.events.find((event) => event.type === 'action_failed')).toBeUndefined();
+  });
+
   it('continues draining movement queue across ticks without new actions', () => {
     const colony = makeColony();
     const settlement = makeSettlement({ population: 0 });

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -5745,27 +5745,6 @@ export function resolveTick(
   const removedUnitIds = new Set([...desertedUnitIds, ...criticalWoundUnitIds]);
   const survivingUnits = updatedUnits.filter(u => !removedUnitIds.has(u.id));
 
-  // Emit action_failed events so failures appear in the event feed
-  for (const ar of actionResults) {
-    if (ar.status === 'failed') {
-      // Find the original action to get colony context
-      const action = actions.find(a => a.id === ar.actionId);
-      if (action) {
-        events.push({
-          type: 'action_failed',
-          colonyId: action.colonyId,
-          data: {
-            actionId: ar.actionId,
-            actionType: action.type,
-            reason: ar.result || 'Unknown error',
-            params: action.params,
-          },
-        });
-      }
-    }
-  }
-
-
   // --- Snapshot Score (recalculated every tick from current state) ---
   for (const colony of updatedColonies) {
     if (colony.status !== 'active') { continue; }


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate action_failed events by keeping failure event emission in the scheduler only.

The tick engine was already returning failed actionResults, and the scheduler converts those into persisted action_failed events. A second action_failed event was also being emitted directly from resolveTick, which meant every failed action showed up twice in the event stream with slightly different payload shapes.

## Related issue

Closes #341

## How to test

1. Submit an action that fails
2. Confirm only one action_failed event is emitted for that actionId
3. Run the full Vitest suite and TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits