### PR TITLE
fix: expose tier 2 tech gates

### DIFF
--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -443,30 +443,54 @@ export const TIER_1_TECHS = Object.values(TECH_TREE)
   .filter((tech) => tech.tier === 1)
   .map((tech) => tech.id);
 
+export function getTechResearchRequirements(techId: TechId, researched: string[]): {
+  directRequires: TechId[];
+  missingDirectRequires: TechId[];
+  tierGate: null | {
+    allTier1Required: true;
+    missingTechs: TechId[];
+  };
+} {
+  const tech = TECH_TREE[techId];
+  const directRequires = tech?.requires ?? [];
+  const missingDirectRequires = directRequires.filter((id) => !researched.includes(id));
+
+  const missingTierOne = tech && tech.tier > 1
+    ? TIER_1_TECHS.filter((id) => !researched.includes(id))
+    : [];
+
+  return {
+    directRequires,
+    missingDirectRequires,
+    tierGate: missingTierOne.length > 0
+      ? {
+          allTier1Required: true,
+          missingTechs: missingTierOne,
+        }
+      : null,
+  };
+}
+
 export function canResearchTech(techId: TechId, researched: string[]): { ok: true } | { ok: false; reason: string } {
   const tech = TECH_TREE[techId];
   if (!tech) {
     return { ok: false, reason: `Unknown tech: ${techId}` };
   }
 
-  if (tech.tier > 1) {
-    const missingTierOne = TIER_1_TECHS.filter((id) => !researched.includes(id));
-    if (missingTierOne.length > 0) {
-      return {
-        ok: false,
-        reason: `Tier 2 research is locked until all Tier 1 techs are complete. Missing: ${missingTierOne.map((id) => TECH_TREE[id].name).join(', ')}`,
-      };
-    }
+  const requirements = getTechResearchRequirements(techId, researched);
+
+  if (requirements.tierGate) {
+    return {
+      ok: false,
+      reason: `Tier 2 research is locked until all Tier 1 techs are complete. Missing: ${requirements.tierGate.missingTechs.map((id) => TECH_TREE[id].name).join(', ')}`,
+    };
   }
 
-  if (tech.requires) {
-    const missing = tech.requires.filter((id) => !researched.includes(id));
-    if (missing.length > 0) {
-      return {
-        ok: false,
-        reason: `Missing prerequisite tech(s): ${missing.map((id) => TECH_TREE[id]?.name ?? id).join(', ')}`,
-      };
-    }
+  if (requirements.missingDirectRequires.length > 0) {
+    return {
+      ok: false,
+      reason: `Missing prerequisite tech(s): ${requirements.missingDirectRequires.map((id) => TECH_TREE[id]?.name ?? id).join(', ')}`,
+    };
   }
 
   return { ok: true };

--- a/src/routes/__tests__/stateRoute.test.ts
+++ b/src/routes/__tests__/stateRoute.test.ts
@@ -122,6 +122,15 @@ describe('State route intel', () => {
       tier: 2,
       status: 'locked',
       requires: ['improved_agriculture'],
+      tierGate: {
+        allTier1Required: true,
+        missingTechs: ['steel_weapons', 'trade_routes', 'siege_engineering'],
+      },
+      missingRequirements: {
+        direct: [],
+        tierGate: ['steel_weapons', 'trade_routes', 'siege_engineering'],
+      },
+      lockReason: 'Tier 2 research is locked until all Tier 1 techs are complete. Missing: Steel Weapons, Trade Routes, Siege Engineering',
     });
     expect(steelWeapons).toMatchObject({
       id: 'steel_weapons',

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -10,7 +10,7 @@ import { eq, and, or, sql } from 'drizzle-orm';
 import { db } from '../db/index.js';
 import { worlds, hexes, colonies, settlements, units, agreements } from '../db/schema/index.js';
 import { requireAuth } from '../middleware/index.js';
-import { TECH_TREE, MIN_SETTLEMENT_DISTANCE, canResearchTech } from '../engine/tick.js';
+import { TECH_TREE, MIN_SETTLEMENT_DISTANCE, canResearchTech, getTechResearchRequirements } from '../engine/tick.js';
 import type { TechId } from '../engine/tick.js';
 import { hexDistance, hexNeighbors } from '../engine/hex.js';
 
@@ -587,23 +587,39 @@ export async function stateRoutes(app: FastifyInstance) {
     const researched: string[] = (colonyData[0] as any)?.researchedTechs ?? [];
     const queue: Array<{ techId: string; ticksRemaining: number }> = (colonyData[0] as any)?.researchQueue ?? [];
 
-    const techs = Object.values(TECH_TREE).map(tech => ({
-      id: tech.id,
-      name: tech.name,
-      description: tech.description,
-      cost: tech.cost,
-      ticks: tech.ticks,
-      tier: tech.tier,
-      requires: tech.requires ?? [],
-      status: researched.includes(tech.id)
-        ? 'researched'
-        : queue.some(q => q.techId === tech.id)
-          ? 'in_progress'
-          : canResearchTech(tech.id, researched).ok
-            ? 'available'
-            : 'locked',
-      ticksRemaining: queue.find(q => q.techId === tech.id)?.ticksRemaining ?? null,
-    }));
+    const techs = Object.values(TECH_TREE).map(tech => {
+      const researchState = canResearchTech(tech.id, researched);
+      const requirements = getTechResearchRequirements(tech.id, researched);
+
+      return {
+        id: tech.id,
+        name: tech.name,
+        description: tech.description,
+        cost: tech.cost,
+        ticks: tech.ticks,
+        tier: tech.tier,
+        requires: requirements.directRequires,
+        tierGate: requirements.tierGate
+          ? {
+              allTier1Required: true,
+              missingTechs: requirements.tierGate.missingTechs,
+            }
+          : null,
+        missingRequirements: {
+          direct: requirements.missingDirectRequires,
+          tierGate: requirements.tierGate?.missingTechs ?? [],
+        },
+        status: researched.includes(tech.id)
+          ? 'researched'
+          : queue.some(q => q.techId === tech.id)
+            ? 'in_progress'
+            : researchState.ok
+              ? 'available'
+              : 'locked',
+        lockReason: researchState.ok ? null : researchState.reason,
+        ticksRemaining: queue.find(q => q.techId === tech.id)?.ticksRemaining ?? null,
+      };
+    });
 
     return {
       colonyId: colony.id,


### PR DESCRIPTION
## What does this PR do?

Fixes the tech endpoint so Tier 2 research requirements are represented accurately.

Previously the API only exposed each tech's direct requires list, even though all Tier 2 techs are also gated behind completion of every Tier 1 tech. That made the endpoint misleading for both players and agents.

This change keeps direct requires, and adds explicit tierGate, missingRequirements, and lockReason fields so the lock state matches the real research rules.

## Related issue

Closes #339

## How to test

1. Query the tech endpoint with an incomplete Tier 1 set
2. Confirm Tier 2 techs show the all-Tier-1 gate and missing techs
3. Run the full Vitest suite and TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits