### PR TITLE
fix: dedupe stockpile decay event spam

### DIFF
--- a/src/engine/__tests__/scheduler.test.ts
+++ b/src/engine/__tests__/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildPublicData, findRemovedUnitIds } from '../scheduler.js';
+import { buildPublicData, eventDedupKey, findRemovedUnitIds } from '../scheduler.js';
 
 describe('buildPublicData', () => {
   it('keeps hex coordinates for public unit_destroyed events', () => {
@@ -39,5 +39,43 @@ describe('findRemovedUnitIds', () => {
     );
 
     expect(removed).toEqual(['unit-b']);
+  });
+});
+
+describe('eventDedupKey', () => {
+  it('deduplicates identical stockpile decay events for the same colony/resource', () => {
+    const event = {
+      type: 'stockpile_decay',
+      colonyId: 'colony-1',
+      data: {
+        resource: 'timber',
+        decayed: 55.5,
+        clamped: 38.5,
+        cap: 3400,
+        hardCeiling: 6800,
+        remaining: 6783,
+      },
+    };
+
+    const first = eventDedupKey(event, false);
+    const second = eventDedupKey({ ...event, data: { ...event.data } }, false);
+
+    expect(first).toBe(second);
+  });
+
+  it('does not deduplicate private combat events', () => {
+    const event = {
+      type: 'combat_resolved',
+      colonyId: 'colony-1',
+      data: {
+        hexX: 7,
+        hexY: -2,
+        casualties: 3,
+        winnerColony: 'colony-1',
+      },
+    };
+
+    expect(eventDedupKey(event, false)).toBeNull();
+    expect(eventDedupKey(event, true)).not.toBeNull();
   });
 });

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -159,15 +159,30 @@ export function findRemovedUnitIds(
     .filter(unitId => !nextUnitIds.has(unitId));
 }
 
-function eventDedupKey(event: { type: string; data: Record<string, unknown> }): string | null {
+export function eventDedupKey(
+  event: { type: string; colonyId?: string; data: Record<string, unknown> },
+  isPublic: boolean,
+): string | null {
   switch (event.type) {
     case 'combat_resolved':
+      if (!isPublic) return null;
       return JSON.stringify({
         type: event.type,
         hexX: event.data.hexX,
         hexY: event.data.hexY,
         casualties: event.data.casualties,
         winnerColony: event.data.winnerColony,
+      });
+    case 'stockpile_decay':
+      return JSON.stringify({
+        type: event.type,
+        colonyId: event.colonyId,
+        resource: event.data.resource,
+        decayed: event.data.decayed,
+        clamped: event.data.clamped,
+        cap: event.data.cap,
+        hardCeiling: event.data.hardCeiling,
+        remaining: event.data.remaining,
       });
     default:
       return null;
@@ -798,7 +813,7 @@ export class TickScheduler {
         for (const event of result.events) {
           const isPublic = PUBLIC_EVENT_TYPES.has(event.type);
           const publicData = isPublic ? buildPublicData(event) : null;
-          const dedupKey = isPublic ? eventDedupKey(event) : null;
+          const dedupKey = eventDedupKey(event, isPublic);
 
           if (dedupKey) {
             const existing = persistedEvents.get(dedupKey);


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate stockpile_decay events by deduplicating identical decay events during scheduler persistence.

The intended behavior is one stockpile_decay event per colony/resource/tick. This change collapses identical duplicates without changing the stockpile math itself.

## Related issue

Closes #343

## How to test

1. Run the scheduler tests
2. Run the full Vitest suite
3. Run TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits