### PR TITLE
fix: preserve source colony on observed events

### DIFF
--- a/src/routes/__tests__/events.test.ts
+++ b/src/routes/__tests__/events.test.ts
@@ -108,6 +108,27 @@ describe('Event Feed', () => {
       expect(colBPrivate).toHaveLength(0);
     });
 
+    it('observed public events should retain source colony context', () => {
+      const observedEvent = {
+        id: 'evt_famine',
+        tick: 10,
+        type: 'famine',
+        public: true,
+        visibility: ['col_b'],
+        data: { colonyId: 'col_b', netFood: -26.55, severity: 0.04 },
+        publicData: { netFood: -26.55, severity: 0.04, colonyId: 'col_b' },
+      };
+
+      const visible = filterVisibleEvents([observedEvent], 'col_a');
+
+      expect(visible).toHaveLength(1);
+      expect(visible[0].publicData).toMatchObject({
+        colonyId: 'col_b',
+        netFood: -26.55,
+        severity: 0.04,
+      });
+    });
+
     it('deduplicated public combat events remain visible to all involved colonies as a single event', () => {
       const events: TestEvent[] = [
         {

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -103,16 +103,29 @@ export async function eventRoutes(app: FastifyInstance) {
     // those get the redacted publicData to prevent information leakage.
     const mappedEvents = rows.map((row) => {
       const isOwnEvent = Array.isArray(row.visibility) && row.visibility.includes(colony.id);
+      const fullPayload = row.data && typeof row.data === 'object'
+        ? row.data as Record<string, unknown>
+        : {};
+      const sourceColonyId = typeof fullPayload.colonyId === 'string'
+        ? fullPayload.colonyId
+        : null;
+      const publicPayload = row.publicData && typeof row.publicData === 'object'
+        ? row.publicData as Record<string, unknown>
+        : fullPayload;
 
       // Use full data for own events, publicData for other colonies' public events
       const eventData = isOwnEvent
-        ? row.data
-        : (row.publicData ?? row.data); // fall back to data if publicData not set
+        ? fullPayload
+        : {
+            ...publicPayload,
+            ...(sourceColonyId ? { colonyId: sourceColonyId } : {}),
+          };
 
       return {
         id: row.id,
         tick: row.tick,
         type: row.type,
+        colonyId: sourceColonyId,
         data: eventData,
         public: row.public,
         own: isOwnEvent, // let clients distinguish own vs observed events


### PR DESCRIPTION
## What does this PR do?

Fixes confusing observed public events in the private /events endpoint by preserving source colony context.

A colony can see its own private production event alongside another colony's public famine event in the same tick. Without source colony context on the observed public event, those can look like contradictory signals from the same actor.

This change keeps the source colonyId on observed public events so clients and players can distinguish their own private production from another colony's public famine or shortage signal.

## Related issue

Closes #342

## How to test

1. Fetch /events for a colony while another colony emits a public famine event
2. Confirm the observed famine event retains source colony context
3. Run the full Vitest suite and TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits