### PR TITLE
fix: aggregate movement blocked event spam

### DIFF
--- a/src/engine/__tests__/scheduler.test.ts
+++ b/src/engine/__tests__/scheduler.test.ts
@@ -78,4 +78,21 @@ describe('eventDedupKey', () => {
     expect(eventDedupKey(event, false)).toBeNull();
     expect(eventDedupKey(event, true)).not.toBeNull();
   });
+
+  it('deduplicates movement_blocked events by colony, hex, and reason', () => {
+    const event = {
+      type: 'movement_blocked',
+      colonyId: 'colony-1',
+      data: {
+        hexX: 35,
+        hexY: -20,
+        reason: 'hex_full',
+      },
+    };
+
+    const first = eventDedupKey(event, false);
+    const second = eventDedupKey({ ...event, unitId: 'unit-2' } as typeof event & { unitId: string }, false);
+
+    expect(first).toBe(second);
+  });
 });

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -184,6 +184,14 @@ export function eventDedupKey(
         hardCeiling: event.data.hardCeiling,
         remaining: event.data.remaining,
       });
+    case 'movement_blocked':
+      return JSON.stringify({
+        type: event.type,
+        colonyId: event.colonyId,
+        hexX: event.data.hexX,
+        hexY: event.data.hexY,
+        reason: event.data.reason,
+      });
     default:
       return null;
   }
@@ -821,6 +829,14 @@ export class TickScheduler {
               if (event.colonyId && !existing.visibility.includes(event.colonyId)) {
                 existing.visibility.push(event.colonyId);
               }
+              if (event.type === 'movement_blocked') {
+                const currentCount = typeof existing.data.blockedUnits === 'number' ? existing.data.blockedUnits : 1;
+                existing.data.blockedUnits = currentCount + 1;
+                const unitIds = Array.isArray(existing.data.unitIds) ? existing.data.unitIds as string[] : [];
+                if (event.unitId && !unitIds.includes(event.unitId)) {
+                  existing.data.unitIds = [...unitIds, event.unitId];
+                }
+              }
               continue;
             }
           }
@@ -836,7 +852,13 @@ export class TickScheduler {
             type: event.type,
             public: isPublic,
             visibility: eventVisibility(event),
-            data: enrichedData,
+            data: event.type === 'movement_blocked'
+              ? {
+                  ...enrichedData,
+                  blockedUnits: 1,
+                  ...(event.unitId ? { unitIds: [event.unitId] } : {}),
+                }
+              : enrichedData,
             ...(publicData ? { publicData } : {}),
           };
 


### PR DESCRIPTION
## What does this PR do?

Fixes movement_blocked event spam by aggregating identical blocked events during scheduler persistence.

When many units are blocked on the same hex for the same reason in a single tick, they now collapse into one persisted event with a blockedUnits count instead of flooding the event log.

## Related issue

Closes #323

## How to test

1. Trigger multiple blocked moves onto the same hex in one tick
2. Confirm a single movement_blocked event is persisted for that hex/reason with an aggregated count
3. Run the full Vitest suite and TypeScript typecheck

## Checklist

- [x] Tests added/updated
- [x] npm test passes
- [x] No any types introduced
- [x] Commit messages follow conventional commits