### PR TITLE
balance: add passive settlement influence

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -4497,4 +4497,47 @@ describe('Edge cases: simultaneous actions (Issue #123)', () => {
     expect(productionEvent?.data.consumed.iron).toBe(2 + FOUNDRY_IRON_CONVERSION_PER_LEVEL);
   });
 
+  it('generates passive influence for each settlement every tick', () => {
+    const colony = makeColony({ resources: { food: 100, timber: 50, stone: 30, iron: 10, influence: 0 } });
+    const settlement = makeSettlement({ population: 0 });
+    const hexes = makeHexRing(0, 0);
+
+    const result = resolveTick([colony], [settlement], [], hexes, []);
+
+    expect(result.colonies[0].resources.influence).toBe(1);
+    const productionEvent = result.events.find((event) => event.type === 'production');
+    expect(productionEvent?.data.produced.influence).toBe(1);
+  });
+
+  it('lets an outpost bank passive influence and upgrade out of a slot deadlock', () => {
+    const colony = makeColony({
+      resources: { food: 300, timber: 200, stone: 150, iron: 50, influence: 24 },
+    });
+    const settlement = makeSettlement({
+      tier: 'outpost',
+      population: 50,
+      buildings: [
+        { type: 'farm', level: 1 },
+        { type: 'lumberMill', level: 1 },
+        { type: 'quarry', level: 1 },
+        { type: 'mine', level: 1 },
+      ],
+    });
+    const hexes = makeHexRing(0, 0);
+
+    const afterIncome = resolveTick([colony], [settlement], [], hexes, []);
+    expect(afterIncome.colonies[0].resources.influence).toBe(25);
+
+    const upgraded = resolveTick(
+      afterIncome.colonies,
+      afterIncome.settlements,
+      [],
+      hexes,
+      [makeUpgradeAction()],
+    );
+
+    expect(upgraded.actionResults.find((result) => result.actionId === 'action-upgrade-1')?.status).toBe('resolved');
+    expect(upgraded.settlements[0].tier).toBe('town');
+  });
+
 });

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -5241,6 +5241,9 @@ export function resolveTick(
     // --- Apply research bonuses ---
     const researched: string[] = (colony as any).researchedTechs ?? [];
 
+    // Baseline political coordination: each settlement generates a small trickle of influence.
+    totalProduction.influence += mySettlements.length;
+
     // Improved Agriculture: +30% food production
     if (researched.includes('improved_agriculture')) {
       totalProduction.food = Math.round(totalProduction.food * 1.3 * 100) / 100;


### PR DESCRIPTION
## What does this PR do?

Adds a small passive influence income per settlement so outposts are not hard-locked from ever reaching the influence cost for their first upgrade.

This specifically fixes the deadlock where an outpost can fill its building slots before getting a market online, leaving it with no path to the influence needed for `upgrade_settlement`.

## Related issue

Closes #338

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run src/engine/__tests__/tick.test.ts`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
3. Verify an outpost with 24 influence gains 1 influence on the next tick and can then upgrade to a town

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] No `any` types introduced
- [x] Commit messages follow conventional commits
