### PR TITLE
balance: strengthen siege support on settlement hexes

### DIFF
--- a/src/engine/__tests__/tick.test.ts
+++ b/src/engine/__tests__/tick.test.ts
@@ -56,6 +56,8 @@ import {
   STOCKPILE_DECAY_RATE,
   HEALING_PER_TICK,
   MAX_UNITS_PER_HEX,
+  SUPPORT_COMBAT_ATTACK_MULTIPLIER,
+  SUPPORT_COMBAT_SETTLEMENT_ATTACK_MULTIPLIER,
   CRITICAL_WOUND_THRESHOLD,
   BARRACKS_HEALING_BONUS,
   SETTLEMENT_LOYALTY_RECOVERY,
@@ -1058,6 +1060,50 @@ describe('resolveMovement', () => {
     expect(combatEvent?.data.participants.some((participant: { unitId: string; supporting?: boolean }) =>
       participant.unitId === 'reinforcement' && participant.supporting === true,
     )).toBe(true);
+  });
+
+  it('makes adjacent support stronger in settlement sieges than in open field combat', () => {
+    const attackerColony = makeColony({ id: 'colony-1' });
+    const defenderColony = makeColony({ id: 'colony-2' });
+    const frontlineAttacker = makeUnit({ id: 'frontline', colonyId: 'colony-1', hexX: 1, hexY: 0, type: 'soldier' });
+    const supportAttacker = makeUnit({ id: 'support', colonyId: 'colony-1', hexX: 0, hexY: 0, type: 'soldier' });
+    const defenders = Array.from({ length: MAX_UNITS_PER_HEX - 1 }, (_, i) =>
+      makeUnit({ id: `defender-${i}`, colonyId: 'colony-2', hexX: 1, hexY: 0, type: 'soldier', health: 100 }),
+    );
+    const actions = [makeAction({ colonyId: 'colony-1', params: { unitId: 'support', targetX: 1, targetY: 0 } })];
+    const hexes = makePlainLine(1);
+
+    const fieldResult = resolveTick(
+      [attackerColony, defenderColony],
+      [],
+      [{ ...frontlineAttacker }, { ...supportAttacker }, ...defenders.map(unit => ({ ...unit }))],
+      hexes,
+      actions,
+      123,
+      'world-1',
+      50,
+    );
+
+    const siegeResult = resolveTick(
+      [attackerColony, defenderColony],
+      [makeSettlement({ id: 'settlement-2', colonyId: 'colony-2', hexX: 1, hexY: 0, population: 20 })],
+      [{ ...frontlineAttacker }, { ...supportAttacker }, ...defenders.map(unit => ({ ...unit }))],
+      hexes,
+      actions,
+      123,
+      'world-1',
+      50,
+    );
+
+    const fieldDefenderHealth = fieldResult.units
+      .filter(unit => unit.colonyId === 'colony-2')
+      .reduce((total, unit) => total + unit.health, 0);
+    const siegeDefenderHealth = siegeResult.units
+      .filter(unit => unit.colonyId === 'colony-2')
+      .reduce((total, unit) => total + unit.health, 0);
+
+    expect(SUPPORT_COMBAT_SETTLEMENT_ATTACK_MULTIPLIER).toBeGreaterThan(SUPPORT_COMBAT_ATTACK_MULTIPLIER);
+    expect(siegeDefenderHealth).toBeLessThan(fieldDefenderHealth);
   });
 });
 

--- a/src/engine/tick.ts
+++ b/src/engine/tick.ts
@@ -859,6 +859,9 @@ export const MAX_UNITS_PER_HEX = 12;
 /** Adjacent military units can support a full contested hex at reduced effectiveness */
 export const SUPPORT_COMBAT_ATTACK_MULTIPLIER = 0.5;
 
+/** Supporting units attack at full strength when reinforcing a siege on a settlement hex */
+export const SUPPORT_COMBAT_SETTLEMENT_ATTACK_MULTIPLIER = 1.0;
+
 /** Supporting units take reduced incoming damage because they fight from adjacent hexes */
 export const SUPPORT_COMBAT_DEFENSE_MULTIPLIER = 0.25;
 
@@ -3099,14 +3102,20 @@ export function resolveCombat(
     }> = [];
 
     for (const attacker of combatParticipants) {
+      const contestedSettlement = settlements?.find(
+        settlement => settlement.hexX === parsedHex?.q && settlement.hexY === parsedHex?.r,
+      );
       const attackerSupporting = supportUnitIds.has(attacker.id);
+      const supportAttackMultiplier = attackerSupporting
+        ? (contestedSettlement ? SUPPORT_COMBAT_SETTLEMENT_ATTACK_MULTIPLIER : SUPPORT_COMBAT_ATTACK_MULTIPLIER)
+        : 1;
       const attackerTechs = researchedTechsByColony.get(attacker.colonyId) ?? new Set<string>();
       const attackPower = (
         UNIT_ATTACK[attacker.type]
         + ((attacker.type === 'militia' || attacker.type === 'soldier') && attackerTechs.has('steel_weapons')
           ? STEEL_WEAPONS_ATTACK_BONUS
           : 0)
-      ) * (attackerSupporting ? SUPPORT_COMBAT_ATTACK_MULTIPLIER : 1);
+      ) * supportAttackMultiplier;
       if (attackPower <= 0) continue; // settlers can't attack
 
       // Find enemy units (from different colony AND not NAP-protected)


### PR DESCRIPTION
## What does this PR do?

Strengthens late-game siege pressure by making adjacent support units attack at full strength when reinforcing combat on a settlement hex.

This keeps open-field support behavior unchanged, but it lets large armies actually concentrate meaningful force against defended settlements instead of freezing into endless hex-cap stalemates.

## Related issue

Closes #322

## How to test

1. Run `/opt/homebrew/opt/node@22/bin/node node_modules/vitest/vitest.mjs run src/engine/__tests__/tick.test.ts`
2. Run `/opt/homebrew/opt/node@22/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
3. Verify adjacent support causes more defender damage on a contested settlement hex than in an equivalent open-field fight

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] No `any` types introduced
- [x] Commit messages follow conventional commits
